### PR TITLE
fix(outputs): persist final completion metadata

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -8,3 +8,7 @@ Ledger of cross-PR tradeoffs. Each entry: decision → consequence for downstrea
 - **`GetReadingByURL` added to `Store`.** Selects all columns except `embedding`. The embedding vector is expensive to transport; if a future caller needs it, fetch by id or add a targeted accessor.
 - **Completion path uses `UpsertReading` unconditionally, and `CreateReading` is removed from the `Store` interface entirely.** The dispatch-time guard covers non-forced duplicates; the only remaining completion-time write paths are `Force=true` (overwrite by design) and the rare concurrent-dispatch race where two read tasks pass their lookup before either writes (for which "upsert" is the benign outcome). The unique index on `readings.url` remains as a crash-rather-than-corrupt backstop.
 - **API still lacks a `force` wire field.** The Discord `/backflow read` command already accepts `force` (default false). REST callers cannot set `Force` until the create endpoint is extended.
+
+## Completion artifact ordering
+
+- **Output logs and metadata snapshots are written in two steps.** The orchestrator now persists `container_output.log` first to obtain `output_url`, then completes the task in Postgres, reloads the finished row, and only then writes `task.json` / `task_metadata.json` and emits completion-side metadata. This avoids stale "running" snapshots at `/output.json` and in S3, at the cost of splitting the writer interface into separate log and metadata calls.

--- a/internal/orchestrator/helpers_test.go
+++ b/internal/orchestrator/helpers_test.go
@@ -468,22 +468,35 @@ func (m *mockDockerManager) GetAgentOutput(_ context.Context, _, _ string) (stri
 // --- Mock filesystem writer ---
 
 type mockWriter struct {
-	saves []mockWriterSave
-	err   error
+	logSaves      []mockWriterLogSave
+	metadataSaves []mockWriterMetadataSave
+	err           error
 }
 
-type mockWriterSave struct {
+type mockWriterLogSave struct {
+	taskID string
+	log    []byte
+}
+
+type mockWriterMetadataSave struct {
 	taskID   string
-	log      []byte
 	metadata any
 }
 
-func (m *mockWriter) Save(_ context.Context, taskID string, logBytes []byte, metadata any) (string, error) {
+func (m *mockWriter) SaveLog(_ context.Context, taskID string, logBytes []byte) (string, error) {
 	if m.err != nil {
 		return "", m.err
 	}
-	m.saves = append(m.saves, mockWriterSave{taskID: taskID, log: logBytes, metadata: metadata})
+	m.logSaves = append(m.logSaves, mockWriterLogSave{taskID: taskID, log: logBytes})
 	return "/api/v1/tasks/" + taskID + "/output", nil
+}
+
+func (m *mockWriter) SaveMetadata(_ context.Context, taskID string, metadata any) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.metadataSaves = append(m.metadataSaves, mockWriterMetadataSave{taskID: taskID, metadata: metadata})
+	return nil
 }
 
 // --- Mock S3 client ---

--- a/internal/orchestrator/monitor.go
+++ b/internal/orchestrator/monitor.go
@@ -79,6 +79,7 @@ func (o *Orchestrator) monitorRunning(ctx context.Context) {
 		if status.Done {
 			o.saveAgentOutput(ctx, task)
 			o.handleCompletion(ctx, task, status)
+			o.saveOutputMetadata(ctx, task)
 			o.saveTaskMetadata(ctx, task)
 		}
 	}
@@ -159,6 +160,9 @@ func (o *Orchestrator) handleCompletion(ctx context.Context, task *models.Task, 
 
 	if err := o.store.CompleteTask(ctx, task.ID, result); err != nil {
 		log.Error().Err(err).Str("task_id", task.ID).Msg("handleCompletion: failed to complete task in store")
+		applyTaskResult(task, result, now)
+	} else {
+		o.refreshCompletedTask(ctx, task, result, now)
 	}
 	o.releaseSlot(ctx, task)
 
@@ -177,6 +181,35 @@ func (o *Orchestrator) handleCompletion(ctx context.Context, task *models.Task, 
 	}
 
 	log.Info().Str("task_id", task.ID).Str("status", string(result.Status)).Msg("task completed")
+}
+
+func (o *Orchestrator) refreshCompletedTask(ctx context.Context, task *models.Task, result store.TaskResult, completedAt time.Time) {
+	storedTask, err := o.store.GetTask(ctx, task.ID)
+	if err != nil {
+		log.Warn().Err(err).Str("task_id", task.ID).Msg("handleCompletion: failed to reload completed task")
+		applyTaskResult(task, result, completedAt)
+		return
+	}
+	*task = *storedTask
+}
+
+func applyTaskResult(task *models.Task, result store.TaskResult, completedAt time.Time) {
+	task.Status = result.Status
+	task.Error = result.Error
+	task.PRURL = result.PRURL
+	task.OutputURL = result.OutputURL
+	task.CostUSD = result.CostUSD
+	task.ElapsedTimeSec = result.ElapsedTimeSec
+	if result.RepoURL != "" {
+		task.RepoURL = result.RepoURL
+	}
+	if result.TargetBranch != "" {
+		task.TargetBranch = result.TargetBranch
+	}
+	if result.TaskMode != "" {
+		task.TaskMode = result.TaskMode
+	}
+	task.CompletedAt = &completedAt
 }
 
 // handleReadingCompletion embeds the agent's final TL;DR and writes the reading
@@ -261,8 +294,8 @@ func agentStatusFromContainer(s ContainerStatus) AgentStatus {
 }
 
 // saveAgentOutput extracts the agent's output log from the container and
-// writes it — alongside a task metadata snapshot — via the configured Writer
-// if the task has save_agent_output enabled.
+// writes it via the configured Writer if the task has save_agent_output
+// enabled.
 func (o *Orchestrator) saveAgentOutput(ctx context.Context, task *models.Task) {
 	if !task.SaveAgentOutput || o.outputs == nil {
 		return
@@ -274,7 +307,7 @@ func (o *Orchestrator) saveAgentOutput(ctx context.Context, task *models.Task) {
 		return
 	}
 
-	url, err := o.outputs.Save(ctx, task.ID, []byte(data), taskMetadataFrom(task))
+	url, err := o.outputs.SaveLog(ctx, task.ID, []byte(data))
 	if err != nil {
 		log.Warn().Err(err).Str("task_id", task.ID).Msg("failed to save agent output")
 		return
@@ -282,6 +315,21 @@ func (o *Orchestrator) saveAgentOutput(ctx context.Context, task *models.Task) {
 
 	task.OutputURL = url
 	log.Debug().Str("task_id", task.ID).Str("url", url).Msg("saved agent output")
+}
+
+// saveOutputMetadata writes the final task metadata snapshot (task.json)
+// alongside the already-persisted agent log.
+func (o *Orchestrator) saveOutputMetadata(ctx context.Context, task *models.Task) {
+	if !task.SaveAgentOutput || o.outputs == nil {
+		return
+	}
+
+	if err := o.outputs.SaveMetadata(ctx, task.ID, taskMetadataFrom(task)); err != nil {
+		log.Warn().Err(err).Str("task_id", task.ID).Msg("failed to save output metadata")
+		return
+	}
+
+	log.Debug().Str("task_id", task.ID).Msg("saved output metadata")
 }
 
 // taskMetadata is the subset of task fields written to S3 after completion.

--- a/internal/orchestrator/monitor_test.go
+++ b/internal/orchestrator/monitor_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -11,6 +13,7 @@ import (
 	"github.com/backflow-labs/backflow/internal/config"
 	"github.com/backflow-labs/backflow/internal/models"
 	"github.com/backflow-labs/backflow/internal/notify"
+	"github.com/backflow-labs/backflow/internal/orchestrator/outputs"
 )
 
 func TestMonitorCancelled_DecrementsRunning(t *testing.T) {
@@ -402,7 +405,7 @@ func TestHandleCompletion_PropagatesInferredFields(t *testing.T) {
 		StartedAt:   &now,
 	})
 
-	bus, _ := newTestBus()
+	bus, n := newTestBus()
 	o := newTestOrchestrator(s, bus)
 	o.running = 1
 
@@ -429,6 +432,17 @@ func TestHandleCompletion_PropagatesInferredFields(t *testing.T) {
 	}
 	if task.TaskMode != "code" {
 		t.Errorf("TaskMode = %q, want %q", task.TaskMode, "code")
+	}
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if len(n.events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(n.events))
+	}
+	if n.events[0].RepoURL != "https://github.com/test/repo" {
+		t.Errorf("event RepoURL = %q, want %q", n.events[0].RepoURL, "https://github.com/test/repo")
+	}
+	if n.events[0].TaskMode != "code" {
+		t.Errorf("event TaskMode = %q, want %q", n.events[0].TaskMode, "code")
 	}
 }
 
@@ -1223,6 +1237,139 @@ func TestMonitorRunning_Completed(t *testing.T) {
 	}
 }
 
+func TestMonitorRunning_Completed_PersistsFinalOutputMetadata(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+
+	s.CreateInstance(context.Background(), &models.Instance{
+		InstanceID:        "local",
+		Status:            models.InstanceStatusRunning,
+		MaxContainers:     4,
+		RunningContainers: 1,
+	})
+	s.CreateTask(context.Background(), &models.Task{
+		ID:              "bf_done_meta",
+		Status:          models.TaskStatusRunning,
+		RepoURL:         "https://github.com/test/repo",
+		Prompt:          "finish me",
+		SaveAgentOutput: true,
+		InstanceID:      "local",
+		ContainerID:     "cont1",
+		StartedAt:       &now,
+		CreatedAt:       now,
+	})
+
+	bus, _ := newTestBus()
+	root := t.TempDir()
+	mock := &mockDockerManager{
+		inspectResults: map[string]ContainerStatus{
+			"local/cont1": {
+				Done:         true,
+				Complete:     true,
+				ExitCode:     0,
+				PRURL:        "https://github.com/test/repo/pull/42",
+				RepoURL:      "https://github.com/test/repo",
+				TargetBranch: "main",
+				TaskMode:     "code",
+			},
+		},
+		agentOutput: "agent log bytes",
+	}
+	o := newTestOrchestrator(s, bus, withDocker(mock), withOutputs(outputs.New(root)))
+	o.running = 1
+
+	o.monitorRunning(context.Background())
+	bus.Close()
+
+	data, err := os.ReadFile(filepath.Join(root, "tasks", "bf_done_meta", "task.json"))
+	if err != nil {
+		t.Fatalf("read task.json: %v", err)
+	}
+
+	var meta taskMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("unmarshal task.json: %v (body: %s)", err, string(data))
+	}
+	if meta.Status != models.TaskStatusCompleted {
+		t.Errorf("status = %q, want %q", meta.Status, models.TaskStatusCompleted)
+	}
+	if meta.PRURL != "https://github.com/test/repo/pull/42" {
+		t.Errorf("PRURL = %q, want PR URL", meta.PRURL)
+	}
+	if meta.OutputURL != "/api/v1/tasks/bf_done_meta/output" {
+		t.Errorf("OutputURL = %q, want output endpoint", meta.OutputURL)
+	}
+	if meta.CompletedAt == nil {
+		t.Error("CompletedAt should be set")
+	}
+}
+
+func TestMonitorRunning_Completed_UploadsFinalTaskMetadata(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+
+	s.CreateInstance(context.Background(), &models.Instance{
+		InstanceID:        "local",
+		Status:            models.InstanceStatusRunning,
+		MaxContainers:     4,
+		RunningContainers: 1,
+	})
+	s.CreateTask(context.Background(), &models.Task{
+		ID:              "bf_done_s3_meta",
+		Status:          models.TaskStatusRunning,
+		RepoURL:         "https://github.com/test/repo",
+		Prompt:          "finish me",
+		SaveAgentOutput: true,
+		InstanceID:      "local",
+		ContainerID:     "cont1",
+		StartedAt:       &now,
+		CreatedAt:       now,
+	})
+
+	bus, _ := newTestBus()
+	writer := &mockWriter{}
+	mockS3 := &mockS3Client{}
+	mock := &mockDockerManager{
+		inspectResults: map[string]ContainerStatus{
+			"local/cont1": {
+				Done:         true,
+				Complete:     true,
+				ExitCode:     0,
+				PRURL:        "https://github.com/test/repo/pull/84",
+				RepoURL:      "https://github.com/test/repo",
+				TargetBranch: "main",
+				TaskMode:     "code",
+			},
+		},
+		agentOutput: "agent log bytes",
+	}
+	o := newTestOrchestrator(s, bus, withDocker(mock), withOutputs(writer), withS3(mockS3))
+	o.running = 1
+
+	o.monitorRunning(context.Background())
+	bus.Close()
+
+	if len(mockS3.uploads) != 1 {
+		t.Fatalf("expected 1 S3 upload, got %d", len(mockS3.uploads))
+	}
+	var meta taskMetadata
+	if err := json.Unmarshal(mockS3.uploads[0].data, &meta); err != nil {
+		t.Fatalf("unmarshal uploaded JSON: %v (body: %s)", err, string(mockS3.uploads[0].data))
+	}
+	if meta.Status != models.TaskStatusCompleted {
+		t.Errorf("status = %q, want %q", meta.Status, models.TaskStatusCompleted)
+	}
+	if meta.PRURL != "https://github.com/test/repo/pull/84" {
+		t.Errorf("PRURL = %q, want PR URL", meta.PRURL)
+	}
+	if meta.OutputURL != "/api/v1/tasks/bf_done_s3_meta/output" {
+		t.Errorf("OutputURL = %q, want output endpoint", meta.OutputURL)
+	}
+	if meta.CompletedAt == nil {
+		t.Error("CompletedAt should be set")
+	}
+}
+
 func TestMonitorRunning_CompletedFromStatusFile(t *testing.T) {
 	s := newMockStore()
 	now := time.Now().UTC()
@@ -1954,23 +2101,18 @@ func TestSaveAgentOutput_WritesViaWriter(t *testing.T) {
 	task, _ := s.GetTask(context.Background(), "bf_fs_out")
 	o.saveAgentOutput(context.Background(), task)
 
-	if len(writer.saves) != 1 {
-		t.Fatalf("expected 1 writer.Save call, got %d", len(writer.saves))
+	if len(writer.logSaves) != 1 {
+		t.Fatalf("expected 1 writer.SaveLog call, got %d", len(writer.logSaves))
 	}
-	save := writer.saves[0]
+	save := writer.logSaves[0]
 	if save.taskID != "bf_fs_out" {
 		t.Errorf("taskID = %q, want %q", save.taskID, "bf_fs_out")
 	}
 	if string(save.log) != "agent log bytes" {
 		t.Errorf("log = %q, want %q", string(save.log), "agent log bytes")
 	}
-
-	meta, ok := save.metadata.(taskMetadata)
-	if !ok {
-		t.Fatalf("metadata = %T, want taskMetadata", save.metadata)
-	}
-	if meta.ID != "bf_fs_out" {
-		t.Errorf("metadata.ID = %q, want %q", meta.ID, "bf_fs_out")
+	if len(writer.metadataSaves) != 0 {
+		t.Fatalf("expected 0 writer.SaveMetadata calls, got %d", len(writer.metadataSaves))
 	}
 
 	if task.OutputURL != "/api/v1/tasks/bf_fs_out/output" {
@@ -2026,8 +2168,8 @@ func TestSaveAgentOutput_GateOffWhenSaveDisabled(t *testing.T) {
 	task, _ := s.GetTask(context.Background(), "bf_fs_gate")
 	o.saveAgentOutput(context.Background(), task)
 
-	if len(writer.saves) != 0 {
-		t.Errorf("expected 0 Save calls (SaveAgentOutput=false), got %d", len(writer.saves))
+	if len(writer.logSaves) != 0 {
+		t.Errorf("expected 0 SaveLog calls (SaveAgentOutput=false), got %d", len(writer.logSaves))
 	}
 	if task.OutputURL != "" {
 		t.Errorf("task.OutputURL = %q, want empty when save gated off", task.OutputURL)

--- a/internal/orchestrator/outputs.go
+++ b/internal/orchestrator/outputs.go
@@ -2,8 +2,9 @@ package orchestrator
 
 import "context"
 
-// Writer persists agent output and task metadata for a completed task and
-// returns a URL under which the API serves the bytes back to callers.
+// Writer persists the agent output log and the final task metadata snapshot
+// for a completed task.
 type Writer interface {
-	Save(ctx context.Context, taskID string, logBytes []byte, metadata any) (string, error)
+	SaveLog(ctx context.Context, taskID string, logBytes []byte) (string, error)
+	SaveMetadata(ctx context.Context, taskID string, metadata any) error
 }

--- a/internal/orchestrator/outputs/fs.go
+++ b/internal/orchestrator/outputs/fs.go
@@ -25,10 +25,9 @@ func New(root string) *FSWriter {
 	return &FSWriter{Root: root}
 }
 
-// Save writes the log bytes and JSON-marshaled metadata for taskID and
-// returns the API-relative URL that serves the log (task.json is served
-// through a sibling endpoint).
-func (w *FSWriter) Save(_ context.Context, taskID string, logBytes []byte, metadata any) (string, error) {
+// SaveLog writes the raw agent log for taskID and returns the API-relative URL
+// that serves it back to callers.
+func (w *FSWriter) SaveLog(_ context.Context, taskID string, logBytes []byte) (string, error) {
 	dir := filepath.Join(w.Root, "tasks", taskID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return "", fmt.Errorf("outputs: mkdir task dir: %w", err)
@@ -38,15 +37,25 @@ func (w *FSWriter) Save(_ context.Context, taskID string, logBytes []byte, metad
 		return "", err
 	}
 
-	data, err := json.MarshalIndent(metadata, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("outputs: marshal metadata: %w", err)
-	}
-	if err := writeAtomic(filepath.Join(dir, "task.json"), data); err != nil {
-		return "", err
+	return "/api/v1/tasks/" + taskID + "/output", nil
+}
+
+// SaveMetadata writes the JSON task metadata snapshot (task.json) for taskID.
+func (w *FSWriter) SaveMetadata(_ context.Context, taskID string, metadata any) error {
+	dir := filepath.Join(w.Root, "tasks", taskID)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("outputs: mkdir task dir: %w", err)
 	}
 
-	return "/api/v1/tasks/" + taskID + "/output", nil
+	data, err := json.MarshalIndent(metadata, "", "  ")
+	if err != nil {
+		return fmt.Errorf("outputs: marshal metadata: %w", err)
+	}
+	if err := writeAtomic(filepath.Join(dir, "task.json"), data); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func writeAtomic(finalPath string, data []byte) error {

--- a/internal/orchestrator/outputs/fs_test.go
+++ b/internal/orchestrator/outputs/fs_test.go
@@ -9,6 +9,16 @@ import (
 	"testing"
 )
 
+func saveArtifacts(t *testing.T, w *FSWriter, taskID string, logBytes []byte, metadata any) {
+	t.Helper()
+	if _, err := w.SaveLog(context.Background(), taskID, logBytes); err != nil {
+		t.Fatalf("SaveLog returned error: %v", err)
+	}
+	if err := w.SaveMetadata(context.Background(), taskID, metadata); err != nil {
+		t.Fatalf("SaveMetadata returned error: %v", err)
+	}
+}
+
 func TestFSWriter_Save_CreatesDirectory(t *testing.T) {
 	root := t.TempDir()
 
@@ -16,9 +26,7 @@ func TestFSWriter_Save_CreatesDirectory(t *testing.T) {
 	// create the per-task directory on demand.
 	w := New(filepath.Join(root, "fresh"))
 
-	if _, err := w.Save(context.Background(), "bf_abc123", []byte("hello"), map[string]string{"id": "bf_abc123"}); err != nil {
-		t.Fatalf("Save returned error: %v", err)
-	}
+	saveArtifacts(t, w, "bf_abc123", []byte("hello"), map[string]string{"id": "bf_abc123"})
 
 	dir := filepath.Join(root, "fresh", "tasks", "bf_abc123")
 	info, err := os.Stat(dir)
@@ -40,9 +48,7 @@ func TestFSWriter_Save_WritesBothFiles(t *testing.T) {
 		"status": "completed",
 	}
 
-	if _, err := w.Save(context.Background(), "bf_meta1", logContent, meta); err != nil {
-		t.Fatalf("Save returned error: %v", err)
-	}
+	saveArtifacts(t, w, "bf_meta1", logContent, meta)
 
 	logPath := filepath.Join(root, "tasks", "bf_meta1", "container_output.log")
 	jsonPath := filepath.Join(root, "tasks", "bf_meta1", "task.json")
@@ -75,9 +81,7 @@ func TestFSWriter_Save_Atomic(t *testing.T) {
 	root := t.TempDir()
 	w := New(root)
 
-	if _, err := w.Save(context.Background(), "bf_atomic", []byte("payload"), map[string]string{"k": "v"}); err != nil {
-		t.Fatalf("Save returned error: %v", err)
-	}
+	saveArtifacts(t, w, "bf_atomic", []byte("payload"), map[string]string{"k": "v"})
 
 	dir := filepath.Join(root, "tasks", "bf_atomic")
 	entries, err := os.ReadDir(dir)
@@ -105,12 +109,8 @@ func TestFSWriter_Save_Overwrites(t *testing.T) {
 	root := t.TempDir()
 	w := New(root)
 
-	if _, err := w.Save(context.Background(), "bf_over", []byte("first"), map[string]string{"v": "1"}); err != nil {
-		t.Fatalf("Save #1 returned error: %v", err)
-	}
-	if _, err := w.Save(context.Background(), "bf_over", []byte("second"), map[string]string{"v": "2"}); err != nil {
-		t.Fatalf("Save #2 returned error: %v", err)
-	}
+	saveArtifacts(t, w, "bf_over", []byte("first"), map[string]string{"v": "1"})
+	saveArtifacts(t, w, "bf_over", []byte("second"), map[string]string{"v": "2"})
 
 	gotLog, err := os.ReadFile(filepath.Join(root, "tasks", "bf_over", "container_output.log"))
 	if err != nil {
@@ -133,16 +133,16 @@ func TestFSWriter_Save_Overwrites(t *testing.T) {
 	}
 }
 
-func TestFSWriter_Save_ReturnsURL(t *testing.T) {
+func TestFSWriter_SaveLog_ReturnsURL(t *testing.T) {
 	root := t.TempDir()
 	w := New(root)
 
-	url, err := w.Save(context.Background(), "bf_url123", []byte("x"), map[string]string{"id": "bf_url123"})
+	url, err := w.SaveLog(context.Background(), "bf_url123", []byte("x"))
 	if err != nil {
-		t.Fatalf("Save returned error: %v", err)
+		t.Fatalf("SaveLog returned error: %v", err)
 	}
 	want := "/api/v1/tasks/bf_url123/output"
 	if url != want {
-		t.Errorf("Save url = %q, want %q", url, want)
+		t.Errorf("SaveLog url = %q, want %q", url, want)
 	}
 }


### PR DESCRIPTION
## Summary
This stacked PR fixes the output metadata regression in the filesystem output work.

## What changed
- split the output writer so the raw log is written before completion and task.json is written only after the task has been completed
- reload the completed task row before writing task.json, uploading task_metadata.json, and emitting completion-side metadata
- keep a local fallback path when the post-completion reload fails so events and metadata still reflect the final result fields
- add regression coverage for final task.json, final S3 metadata, completion event fields, and the split filesystem writer behavior

## Verification
- go test ./internal/orchestrator/... -count=1
- go test ./internal/api -run TestGetTaskOutput|TestGetTaskOutputJSON -count=1

## Notes
- base branch: feat/fs-outputs
- related stack PR: #9