### PR TITLE
Add read-url.sh helper for submitting reading-mode tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ mise.toml
 .claude/worktrees/
 logs/
 backflow
+data/

--- a/scripts/create-task.sh
+++ b/scripts/create-task.sh
@@ -3,16 +3,19 @@ set -euo pipefail
 
 # Create a task via the Backflow API
 #
+# The prompt must include a GitHub URL — the agent's prep stage infers
+# repo_url, target_branch, and task_type from the prompt text.
+#
 # Usage:
-#   ./scripts/create-task.sh <repo_url> <prompt> [options]
-#   ./scripts/create-task.sh <repo_url> --plan <file> [options]
+#   ./scripts/create-task.sh <prompt> [options]
+#   ./scripts/create-task.sh --plan <file> [options]
 #
 # Examples:
-#   ./scripts/create-task.sh https://github.com/org/repo "Fix the login bug"
-#   ./scripts/create-task.sh https://github.com/org/repo "Add unit tests" --model claude-sonnet-4-6
-#   ./scripts/create-task.sh https://github.com/org/repo "Refactor auth" --pr-title "Refactor auth module" --budget 20
-#   ./scripts/create-task.sh https://github.com/org/repo "Fix bug" --no-pr --effort low
-#   ./scripts/create-task.sh https://github.com/org/repo --plan plan.md --self-review
+#   ./scripts/create-task.sh "Fix the login bug in https://github.com/org/repo"
+#   ./scripts/create-task.sh "Add unit tests to github.com/org/repo" --model claude-sonnet-4-6
+#   ./scripts/create-task.sh "Refactor auth in https://github.com/org/repo" --pr-title "Refactor auth" --budget 20
+#   ./scripts/create-task.sh "Fix bug in https://github.com/org/repo" --no-pr --effort low
+#   ./scripts/create-task.sh --plan plan.md --self-review
 #
 # For PR reviews, use ./scripts/review-pr.sh instead.
 
@@ -20,8 +23,10 @@ BACKFLOW_URL="${BACKFLOW_URL:-http://localhost:8080}"
 
 usage() {
     cat <<USAGE
-Usage: $(basename "$0") <repo_url> <prompt> [options]
-       $(basename "$0") <repo_url> --plan <file> [options]
+Usage: $(basename "$0") <prompt> [options]
+       $(basename "$0") --plan <file> [options]
+
+The prompt must include a GitHub URL so the agent can infer the repo.
 
 Options:
   --plan <file>           Read prompt from a file (use instead of <prompt> arg)
@@ -46,14 +51,11 @@ USAGE
     exit 1
 }
 
-if [ $# -lt 2 ]; then
+if [ $# -lt 1 ]; then
     usage
 fi
 
-REPO_URL="$1"
-shift 1
-
-# If the next argument is a flag (starts with --), prompt must come from --plan
+# If the first argument is a flag (starts with --), prompt must come from --plan
 if [[ "$1" == --* ]]; then
     PROMPT=""
 else
@@ -118,7 +120,6 @@ fi
 
 # Build JSON payload
 JSON=$(jq -n \
-    --arg repo_url "$REPO_URL" \
     --arg prompt "$PROMPT" \
     --arg harness "$HARNESS" \
     --arg branch "$BRANCH" \
@@ -136,7 +137,6 @@ JSON=$(jq -n \
     --arg claude_md "$CLAUDE_MD" \
     --arg context "$CONTEXT" \
     '{
-        repo_url: $repo_url,
         prompt: $prompt
     }
     + if $harness != "" then {harness: $harness} else {} end

--- a/scripts/read-url.sh
+++ b/scripts/read-url.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Submit a URL for reading-mode summarization via the Backflow API.
+#
+# The reader container fetches the URL, drafts a TL;DR, and persists a row
+# in the `readings` table (embedded via OpenAI). A duplicate URL is rejected
+# at dispatch unless --force is passed.
+#
+# Usage:
+#   ./scripts/read-url.sh <url> [options]
+#
+# Examples:
+#   ./scripts/read-url.sh https://example.com/article
+#   ./scripts/read-url.sh https://example.com/article --force
+#   ./scripts/read-url.sh https://example.com/article --context "Focus on the caching section"
+#   ./scripts/read-url.sh https://example.com/article --budget 0.5 --runtime 300
+
+BACKFLOW_URL="${BACKFLOW_URL:-http://localhost:8080}"
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") <url> [options]
+
+Arguments:
+  url                     URL to fetch and summarize
+
+Options:
+  --force                 Overwrite an existing reading row for this URL
+  --harness <name>        Agent harness: claude_code or codex (defaults to server setting)
+  --model <model>         Model to use (defaults to server setting for the selected harness)
+  --effort <level>        Reasoning effort: low, medium, high (defaults to server setting)
+  --budget <usd>          Max budget in USD
+  --runtime <sec>         Max runtime in seconds
+  --turns <n>             Max conversation turns
+  --context <text>        Additional context for the reader
+  --claude-md <text>      Extra CLAUDE.md content to inject
+  --no-save-output        Skip saving agent output to disk
+  --env <KEY=VALUE>       Environment variable (can repeat)
+USAGE
+    exit 1
+}
+
+if [ $# -lt 1 ]; then
+    usage
+fi
+
+URL="$1"
+shift
+
+if ! [[ "$URL" =~ ^https?:// ]]; then
+    echo "Error: expected an http(s) URL, got '$URL'" >&2
+    exit 1
+fi
+
+# Defaults — empty means "let the server decide"
+FORCE=""
+HARNESS=""
+MODEL=""
+EFFORT=""
+BUDGET=""
+RUNTIME=""
+TURNS=""
+CONTEXT=""
+CLAUDE_MD=""
+SAVE_AGENT_OUTPUT=""
+declare -a ENV_VARS=()
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --force)          FORCE=true; shift ;;
+        --harness)        HARNESS="$2"; shift 2 ;;
+        --model)          MODEL="$2"; shift 2 ;;
+        --effort)         EFFORT="$2"; shift 2 ;;
+        --budget)         BUDGET="$2"; shift 2 ;;
+        --runtime)        RUNTIME="$2"; shift 2 ;;
+        --turns)          TURNS="$2"; shift 2 ;;
+        --context)        CONTEXT="$2"; shift 2 ;;
+        --claude-md)      CLAUDE_MD="$2"; shift 2 ;;
+        --no-save-output) SAVE_AGENT_OUTPUT=false; shift ;;
+        --env)            ENV_VARS+=("$2"); shift 2 ;;
+        *)                echo "Unknown option: $1"; usage ;;
+    esac
+done
+
+JSON=$(jq -n \
+    --arg url "$URL" \
+    --arg force "$FORCE" \
+    --arg harness "$HARNESS" \
+    --arg model "$MODEL" \
+    --arg effort "$EFFORT" \
+    --arg budget "$BUDGET" \
+    --arg runtime "$RUNTIME" \
+    --arg turns "$TURNS" \
+    --arg context "$CONTEXT" \
+    --arg claude_md "$CLAUDE_MD" \
+    --arg save_agent_output "$SAVE_AGENT_OUTPUT" \
+    '{
+        task_mode: "read",
+        prompt: $url
+    }
+    + if $force != "" then {force: ($force == "true")} else {} end
+    + if $harness != "" then {harness: $harness} else {} end
+    + if $model != "" then {model: $model} else {} end
+    + if $effort != "" then {effort: $effort} else {} end
+    + if $budget != "" then {max_budget_usd: ($budget | tonumber)} else {} end
+    + if $runtime != "" then {max_runtime_sec: ($runtime | tonumber)} else {} end
+    + if $turns != "" then {max_turns: ($turns | tonumber)} else {} end
+    + if $context != "" then {context: $context} else {} end
+    + if $claude_md != "" then {claude_md: $claude_md} else {} end
+    + if $save_agent_output != "" then {save_agent_output: ($save_agent_output == "true")} else {} end
+    ')
+
+if [ ${#ENV_VARS[@]} -gt 0 ]; then
+    ENV_JSON="{}"
+    for pair in "${ENV_VARS[@]}"; do
+        key="${pair%%=*}"
+        value="${pair#*=}"
+        ENV_JSON=$(echo "$ENV_JSON" | jq --arg k "$key" --arg v "$value" '. + {($k): $v}')
+    done
+    JSON=$(echo "$JSON" | jq --argjson env "$ENV_JSON" '. + {env_vars: $env}')
+fi
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+    -X POST "${BACKFLOW_URL}/api/v1/tasks" \
+    -H "Content-Type: application/json" \
+    -d "$JSON")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" = "201" ]; then
+    echo "$BODY" | jq .
+    TASK_ID=$(echo "$BODY" | jq -r '.data.id')
+    echo ""
+    echo "Useful commands:"
+    echo "  # Get task status"
+    echo "  curl -s ${BACKFLOW_URL}/api/v1/tasks/${TASK_ID} | jq ."
+    echo ""
+    echo "  # Stream logs"
+    echo "  curl -s ${BACKFLOW_URL}/api/v1/tasks/${TASK_ID}/logs"
+    echo ""
+    echo "  # Fetch agent output"
+    echo "  curl -s ${BACKFLOW_URL}/api/v1/tasks/${TASK_ID}/output"
+    echo ""
+    echo "  # Cancel task"
+    echo "  curl -s -X DELETE ${BACKFLOW_URL}/api/v1/tasks/${TASK_ID} | jq ."
+else
+    echo "Error (HTTP $HTTP_CODE):" >&2
+    echo "$BODY" | jq . 2>/dev/null || echo "$BODY" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

  - Add `scripts/read-url.sh`, a convenience wrapper around `POST /api/v1/tasks` for
    submitting a URL to reading-mode summarization.
  - Supports the full set of per-task overrides (`--force`, `--harness`, `--model`,
    `--effort`, `--budget`, `--runtime`, `--turns`, `--context`, `--claude-md`,
    `--no-save-output`, repeated `--env KEY=VALUE`), with empty defaults so the
    server's configured defaults win unless a flag is set.
  - On a `201` response, prints the task JSON plus ready-to-copy `curl` snippets
    for fetching status, streaming logs, retrieving agent output, and cancelling.

  ## Why

  Reading-mode tasks (`task_mode: read`) were already supported end-to-end, but
  the only way to submit one by hand was to assemble a JSON body and POST it with
  `curl`. This script makes the common path one command while still letting power
  users override any field.

  ## Test plan

  - [ ] `./scripts/read-url.sh` with no args prints usage and exits 1
  - [ ] `./scripts/read-url.sh not-a-url` rejects non-http(s) input
  - [x] `./scripts/read-url.sh https://example.com/article` creates a read task
        against a running local server (`make run`)
  - [ ] `./scripts/read-url.sh <dup-url>` fails with the dispatch-time duplicate
        error; re-running with `--force` overwrites the existing reading row
  - [ ] `--env FOO=bar --env BAZ=qux` shows up in the task's `env_vars`
  - [ ] Non-2xx responses print the error body and exit 1