### PR TITLE
ci(claude): fix review workflow triggers — listen for @claude mentions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,25 +3,13 @@ name: Claude Code Review
 on:
   pull_request:
     types: [review_requested]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -36,9 +24,21 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
 
+            Please review this pull request with a focus on:
+            - Code quality and best practices
+            - Potential bugs or issues
+            - Security implications
+            - Performance considerations
+
+            Note: The PR branch is already checked out in the current working directory.
+
+            Use `gh pr comment` for top-level feedback.
+            Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
+            Only post GitHub comments - don't submit review text as messages.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,39 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
## Summary

The `Claude Code Review` workflow added in #17 never produced a successful review. It only triggers on `pull_request: [review_requested]`, which requires someone to explicitly click "Request review" in the GitHub UI — nothing listens for `@claude` mentions in comments.

This PR splits the behavior into two workflows, mirroring the working setup in `backflow-labs/backflow`:

- **`.github/workflows/claude-code-review.yml`** (rewrite)
  - Keeps the `review_requested` trigger.
  - Drops the `code-review` plugin; uses an inline review prompt instead (less fragile, no plugin-marketplace fetch).
  - `permissions.pull-requests`: `read` → `write` so the action can post review comments.
  - Adds `claude_args` with `--allowedTools` to lock the toolset to `gh pr comment`, `gh pr diff`, `gh pr view`, and the inline-comment MCP tool.

- **`.github/workflows/claude.yml`** (new)
  - Triggers: `issue_comment`, `pull_request_review_comment`, `pull_request_review`, `issues`.
  - Job-level `if:` gate requires `@claude` in the body or title, so unrelated comments don't spend runner minutes.
  - No `prompt:` input — the action uses the triggering comment body as the instruction, which is what makes `@claude review this PR` actually do something.
  - Grants `actions: read` so Claude can pull CI status when replying.

## Why two files, not one

The two jobs have meaningfully different contracts (automation with a fixed prompt + locked tools vs. interactive with a user-authored prompt + wider tools). Collapsing them would require conditional multi-line `prompt:` and `claude_args:` values based on `github.event_name`, plus over-granting job-level `permissions:`. Two files reads cleaner and matches the reference repo.

## Test plan

Workflow triggers can't be exercised locally. After this PR merges (and a reviewer is re-requested / a comment is added):

- [ ] Comment `@claude review this PR` on an open PR → new run appears under `Claude Code` workflow (event `issue_comment`), action posts review comments back.
- [ ] Click "Request review" in the GitHub UI on an open PR → new run appears under `Claude Code Review` workflow (event `pull_request` / action `review_requested`), action posts review via `gh pr comment` + inline comments.
- [ ] Post a PR comment without `@claude` (e.g. `lgtm`) → no new run under either workflow.
- [ ] Open an issue with `@claude` in the title or body → new run under `Claude Code` workflow (event `issues`).

The first `review_requested` run on this PR itself may fail with GitHub's "workflow file must exist on default branch" validation error — that's expected and resolves once this PR merges to `main`.