### PR TITLE
Write container_output.log outside the git workspace

### DIFF
--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -239,7 +239,7 @@ Do NOT comment on:
 
 You MUST post your review as a comment on the PR using the gh CLI. Do not just print your review to stdout."
 
-    CLAUDE_LOG="${WORKSPACE}/container_output.log"
+    CLAUDE_LOG="/tmp/container_output.log"
     set +e
     if [ "$HARNESS" = "codex" ]; then
         CODEX_REVIEW_ARGS=(
@@ -394,7 +394,7 @@ while [ $ATTEMPT -lt "$MAX_RETRIES" ]; do
     ATTEMPT=$((ATTEMPT + 1))
     echo "==> Running ${HARNESS} (attempt ${ATTEMPT}/${MAX_RETRIES})..."
 
-    CLAUDE_LOG="${WORKSPACE}/container_output.log"
+    CLAUDE_LOG="/tmp/container_output.log"
     set +e
     if [ "$HARNESS" = "codex" ]; then
         build_codex_args "$FULL_PROMPT"

--- a/docker/reader/reader-entrypoint.sh
+++ b/docker/reader/reader-entrypoint.sh
@@ -127,7 +127,7 @@ Do not write any other files. Do not make commits or PRs."
 # =============================================================================
 
 cd "$WORKSPACE"
-HARNESS_LOG="${WORKSPACE}/container_output.log"
+HARNESS_LOG="/tmp/container_output.log"
 
 echo "==> Running ${HARNESS} for URL: ${URL}"
 set +e

--- a/internal/orchestrator/docker/docker.go
+++ b/internal/orchestrator/docker/docker.go
@@ -296,8 +296,10 @@ func (m *Manager) enrichFromStatusJSON(ctx context.Context, instanceID, containe
 }
 
 // GetAgentOutput extracts the agent's output log from a container via docker cp.
+// The agent writes this log to /tmp (outside the git workspace) so the agent's
+// own git operations cannot clobber it.
 func (m *Manager) GetAgentOutput(ctx context.Context, instanceID, containerID string) (string, error) {
-	cmd := fmt.Sprintf("f=$(mktemp) && docker cp %s:/home/agent/workspace/container_output.log \"$f\" 2>/dev/null && cat \"$f\" && rm -f \"$f\"", containerID)
+	cmd := fmt.Sprintf("f=$(mktemp) && docker cp %s:/tmp/container_output.log \"$f\" && cat \"$f\" && rm -f \"$f\"", containerID)
 	return m.runCommand(ctx, instanceID, cmd)
 }
 


### PR DESCRIPTION
## Summary

Fixes an intermittent `failed to extract agent output log error="local command failed: exit status 1"` warning observed after codex code-mode tasks completed successfully (e.g. `bf_01KPSJ3E8HBFW5KEVZQYS0F45V`).

**Root cause.** `docker/agent/entrypoint.sh` tees the harness stdout into `${WORKSPACE}/container_output.log`, but `$WORKSPACE` is the cloned repo the agent then manipulates. The agent's own git operations — `git add -A`, or the codex CLI's internal housekeeping — can delete or move the untracked log file before `handleCompletion` runs `docker cp`. When that happens, `docker cp` exits 1 and the orchestrator logs a warning on an otherwise-completed task. I reproduced it by running `docker cp` directly against the still-live container for that task: `Error response from daemon: Could not find the file /home/agent/workspace/container_output.log …`. `status.json` survives because it's written after the commit/push step.

**Fix.**

- Move the log out of the git workspace to `/tmp/container_output.log` in both `docker/agent/entrypoint.sh` (code + review modes) and `docker/reader/reader-entrypoint.sh`. The agent can't see, commit, or `git clean` it from there.
- Update `Manager.GetAgentOutput` in `internal/orchestrator/docker/docker.go` to `docker cp` from `/tmp/container_output.log`.
- Drop the `2>/dev/null` on the `docker cp` so if this ever fails again, the real error (from `runCommand`'s stderr capture) shows up in the log instead of a bare `exit status 1`.

No test changes — the host-side filename in `outputs/fs.go` is unchanged, and existing unit tests for orchestrator/api/outputs pass.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/orchestrator/... ./internal/api/...`
- [x] `make docker-agent-build-local`
- [x] `make docker-reader-build-local`
- [ ] Run a real codex code-mode task end-to-end and confirm `container_output.log` is persisted under `BACKFLOW_DATA_DIR/tasks/<id>/` and no "failed to extract agent output log" warning appears.
- [ ] Run a reader-mode task and confirm the harness log still streams into `/api/v1/tasks/<id>/output`.