### PR TITLE
[backflow] Run fuzz job only on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         run: go test ./test/blackbox/ -v -count=1 -timeout 120s
 
   fuzz:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
 
     services:


### PR DESCRIPTION
## Summary
- Adds `if: github.event_name == 'push'` to the `fuzz` job in `.github/workflows/ci.yml` so the schemathesis fuzz suite no longer runs on pull requests.
- The job still runs on merges/pushes to `main`, so fuzz coverage happens at merge time to the default branch.

## Why
The schemathesis fuzz job spins up Postgres + the server and runs stateful fuzzing, which slows PR feedback. Keeping the other checks (`static`, `test`, `blackbox`) on PRs preserves fast signal, while `fuzz` moves to post-merge so it still guards `main`.

## Test plan
- [ ] On this PR, confirm the `fuzz` job is skipped and `static`, `test`, `blackbox` still run.
- [ ] After merge to `main`, confirm the `fuzz` job runs on the push event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)