### PR TITLE
[backflow] Rename runtime to backlite and refresh self-hosting docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# Backflow server configuration
+# Backlite server configuration
 
 # Required
 ANTHROPIC_API_KEY=sk-ant-...
@@ -11,18 +11,18 @@ GITHUB_TOKEN=ghp_...
 
 # Server
 BACKFLOW_LISTEN_ADDR=:8080
-BACKFLOW_DATABASE_PATH=./backflow.db
+BACKFLOW_DATABASE_PATH=./backlite.db
 
-# Agent image (default: backflow-agent; set to fake-agent for local blackbox/soak testing)
-# BACKFLOW_AGENT_IMAGE=backflow-fake-agent
+# Agent image (set this if you publish a non-default tag; use backlite-fake-agent for local blackbox/soak testing)
+# BACKFLOW_AGENT_IMAGE=backlite-fake-agent
 
-# Reader image (reading-mode tasks — /backflow read, task_mode=read)
+# Reader image (used only for task_mode=read)
 # When BACKFLOW_READER_IMAGE is set, the following are required:
 #   - BACKFLOW_DEFAULT_READ_MAX_BUDGET > 0
 #   - BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC > 0
 #   - BACKFLOW_DEFAULT_READ_MAX_TURNS > 0
 #   - OPENAI_API_KEY (for the orchestrator's embeddings client)
-# BACKFLOW_READER_IMAGE=backflow-reader
+# BACKFLOW_READER_IMAGE=backlite-reader
 # BACKFLOW_DEFAULT_READ_MAX_BUDGET=0.5
 # BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC=300
 # BACKFLOW_DEFAULT_READ_MAX_TURNS=20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           cache: true
 
       - name: Build
-        run: go build -trimpath -o bin/backflow ./cmd/backflow
+        run: go build -trimpath -o bin/backlite ./cmd/backlite
 
       - name: Test
         run: go test $(go list ./... | grep -v '/test/blackbox') -race -v -count=1
@@ -86,25 +86,25 @@ jobs:
 
       - name: Run migrations
         run: |
-          rm -f /tmp/backflow-ci.db
-          goose -dir migrations sqlite3 /tmp/backflow-ci.db up
+          rm -f /tmp/backlite-ci.db
+          goose -dir migrations sqlite3 /tmp/backlite-ci.db up
 
       - name: Build
-        run: go build -trimpath -o bin/backflow ./cmd/backflow
+        run: go build -trimpath -o bin/backlite ./cmd/backlite
 
       - name: Start server
         run: |
-          ./bin/backflow &
-          echo $! > /tmp/backflow.pid
+          ./bin/backlite &
+          echo $! > /tmp/backlite.pid
         env:
-          BACKFLOW_DATABASE_PATH: /tmp/backflow-ci.db
+          BACKFLOW_DATABASE_PATH: /tmp/backlite-ci.db
           ANTHROPIC_API_KEY: sk-ant-fuzz-placeholder-not-real
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Wait for server
         run: |
           for i in $(seq 1 15); do
-            if ! kill -0 "$(cat /tmp/backflow.pid)" 2>/dev/null; then
+            if ! kill -0 "$(cat /tmp/backlite.pid)" 2>/dev/null; then
               echo "server process died" && exit 1
             fi
             curl -sf http://localhost:8080/health && break || sleep 1

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,5 @@ mise.toml
 .hypothesis/
 .claude/worktrees/
 logs/
-backflow
+backlite
 data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What This Is
 
-Backflow is a Go service that runs coding agents (Claude Code or Codex) in ephemeral containers. Tasks come in via REST API; the orchestrator provisions infrastructure, runs agents, and cleans up.
+Backlite is a Go service that runs coding agents (Claude Code or Codex) in ephemeral containers. Tasks come in via REST API; the orchestrator provisions infrastructure, runs agents, and cleans up.
 
 Three task modes: `code` (default: clone → code → commit → PR), `review` (PR review with inline comments), and `read` (fetch a URL, summarize it via a reader agent, embed the TL;DR, store the result in the `readings` table for later similarity search).
 
@@ -16,7 +16,7 @@ Three task modes: `code` (default: clone → code → commit → PR), `review` (
 ## Commands
 
 ```bash
-make build              # Build to bin/backflow
+make build              # Build to bin/backlite
 make run                # Build + run (sources .env if present)
 make test               # Unit/integration tests with -tags nocontainers (excludes blackbox; see make test-blackbox)
 make lint               # go vet ./...
@@ -82,7 +82,7 @@ Minimal Alpine image used by black-box and soak tests. Reads `FAKE_OUTCOME` env 
 
 ### Soak test (`test/soak/`)
 
-Long-running resource leak detector. Submits tasks at intervals, collects RSS, pool stats, and container counts, then analyzes for memory growth and container accumulation. Run via `make test-soak` (10-min short mode). It derives a sibling `-soak.db` path from `BACKFLOW_DATABASE_PATH`, starts a dedicated Backflow subprocess against that database, truncates the soak tables there, and prunes stale containers at start and end. The wrapper script (`scripts/test-soak.sh`) warns before truncating and asks for confirmation.
+Long-running resource leak detector. Submits tasks at intervals, collects RSS, pool stats, and container counts, then analyzes for memory growth and container accumulation. Run via `make test-soak` (10-min short mode). It derives a sibling `-soak.db` path from `BACKFLOW_DATABASE_PATH`, starts a dedicated Backlite subprocess against that database, truncates the soak tables there, and prunes stale containers at start and end. The wrapper script (`scripts/test-soak.sh`) warns before truncating and asks for confirmation.
 
 ### Agent container (`docker/agent/`)
 
@@ -117,8 +117,8 @@ The reading agent image and reader-side shell scripts live in `docker/reader/`:
 
 - `reader-entrypoint.sh` — Image entrypoint: runs the harness, extracts JSON via `reader_helpers.sh`, writes `status.json` via `status_writer.sh`.
 - `read-embed.sh` — Embeds text via OpenAI `text-embedding-3-small`. Used by the agent to embed a draft TL;DR for similarity search.
-- `read-similar.sh` — Semantic similarity search: embeds input text, calls Backflow's `/api/v1/readings/similar` endpoint.
-- `read-lookup.sh` — Exact-URL duplicate check via Backflow's `/api/v1/readings/lookup` endpoint.
+- `read-similar.sh` — Semantic similarity search: embeds input text, calls Backlite's `/api/v1/readings/similar` endpoint.
+- `read-lookup.sh` — Exact-URL duplicate check via Backlite's `/api/v1/readings/lookup` endpoint.
 - `reader_helpers.sh` — JSON extraction helpers (pulls the first JSON object from the agent transcript).
 - `status_writer.sh` — Shared helper for writing `status.json`.
 
@@ -127,7 +127,7 @@ Reading-mode env vars:
 - `BACKFLOW_READER_IMAGE` — Docker image for reading-mode containers
 - `BACKFLOW_DEFAULT_READ_MAX_BUDGET` / `BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC` / `BACKFLOW_DEFAULT_READ_MAX_TURNS` — Tighter defaults applied by `TaskDefaults("read")`
 - `OPENAI_API_KEY` — Required for the orchestrator's embeddings client (and for the reader container's `read-embed.sh`)
-- `BACKFLOW_INTERNAL_API_BASE_URL` — Optional override for the Backflow API base URL used by reader containers; defaults to `http://host.docker.internal:<listen-port>`
+- `BACKFLOW_INTERNAL_API_BASE_URL` — Optional override for the Backlite API base URL used by reader containers; defaults to `http://host.docker.internal:<listen-port>`
 
 The `tasks` table carries a `force` boolean column. REST callers can set `force` on `POST /api/v1/tasks`; `Force=true` bypasses the dispatch-time duplicate check and allows an existing reading row to be overwritten on completion.
 
@@ -158,7 +158,7 @@ When API keys are configured, bearer auth applies to `/api/v1/*` and `/debug/sta
 
 ## AWS teardown
 
-Backflow no longer provisions or depends on AWS. If a prior deploy ran `make setup-aws`, use `make teardown-aws` to remove the leftover ECS cluster, EC2 launch template / security group, S3 bucket (versions + delete markers), IAM roles/policies/instance profile, CloudWatch log group, and ECR repositories. The script defaults to dry-run — pass `ARGS="--yes"` to actually delete, and `ARGS="--yes --include-fly-user"` if the optional `backflow-fly` IAM user was provisioned. Resource identifiers are sourced from `scripts/aws-resource-names.sh`, shared with `scripts/setup-aws.sh` so the two scripts can't drift.
+Backlite no longer provisions or depends on AWS. If a prior deploy ran `make setup-aws`, use `make teardown-aws` to remove the leftover ECS cluster, EC2 launch template / security group, S3 bucket (versions + delete markers), IAM roles/policies/instance profile, CloudWatch log group, and ECR repositories. The script defaults to dry-run — pass `ARGS="--yes"` to actually delete, and `ARGS="--yes --include-fly-user"` if the optional `backflow-fly` IAM user was provisioned. Resource identifiers are sourced from `scripts/aws-resource-names.sh`, shared with `scripts/setup-aws.sh` so the two scripts can't drift.
 
 ## Documentation guidelines
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -5,7 +5,7 @@ Ledger of cross-PR tradeoffs. Each entry: decision → consequence for downstrea
 ## SQLite migration
 
 - **Persistence now uses a local SQLite file, not Postgres/Supabase.** The server opens `BACKFLOW_DATABASE_PATH`, runs SQLite-compatible goose migrations, and keeps DB-backed tests on temporary `-test.db` files. Anything that still assumes `BACKFLOW_DATABASE_URL`, `pgx`, or Postgres-native SQL needs to be updated rather than worked around.
-- **Reader duplicate/similarity helpers now call Backflow's own API, not Supabase PostgREST.** Read-mode containers receive `BACKFLOW_API_BASE_URL` (plus `BACKFLOW_API_KEY` when configured) and hit `/api/v1/readings/lookup` and `/api/v1/readings/similar`. If a deployment can't use the default host-gateway URL, set `BACKFLOW_INTERNAL_API_BASE_URL` explicitly.
+- **Reader duplicate/similarity helpers now call Backlite's own API, not Supabase PostgREST.** Read-mode containers receive `BACKFLOW_API_BASE_URL` (plus `BACKFLOW_API_KEY` when configured) and hit `/api/v1/readings/lookup` and `/api/v1/readings/similar`. If a deployment can't use the default host-gateway URL, set `BACKFLOW_INTERNAL_API_BASE_URL` explicitly.
 - **Embedding similarity moved from DB-native vector search to application-side ranking.** Readings store embeddings as JSON text in SQLite and `FindSimilarReadings` computes cosine similarity in Go. This keeps the migration simple and local-first, but very large reading corpora may eventually want an explicit ANN/indexed replacement instead of in-process ranking.
 
 ## Duplicate-URL handling for read-mode tasks

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@
        teardown-aws deps test-docker-status-writer test-reader-status-writer \
        test-reader-scripts
 
-BINARY := backflow
-PKG := github.com/backflow-labs/backflow
+BINARY := backlite
+PKG := github.com/brian-bell/backlite
 GOFLAGS := -trimpath
 export PATH := $(HOME)/.local/go/bin:$(HOME)/go/bin:$(PATH)
 
@@ -18,7 +18,7 @@ DOCKER ?= docker
 ENV = if [ -f .env ]; then set -a; . ./.env; set +a; fi
 
 build:
-	go build $(GOFLAGS) -o bin/$(BINARY) ./cmd/backflow
+	go build $(GOFLAGS) -o bin/$(BINARY) ./cmd/backlite
 
 run: build
 	@set -e; \
@@ -39,7 +39,7 @@ test-reader-scripts:
 	bash docker/reader/test_entrypoint.sh
 
 docker-fake-agent-build:
-	$(DOCKER) build -t backflow-fake-agent test/blackbox/fake-agent/
+	$(DOCKER) build -t backlite-fake-agent test/blackbox/fake-agent/
 
 test-fake-agent: docker-fake-agent-build
 	go test ./test/blackbox/fake-agent/ -v -count=1
@@ -62,29 +62,29 @@ clean:
 docker-agent-build:
 	$(DOCKER) buildx build \
 		--platform linux/amd64,linux/arm64 \
-		-t backflow-agent \
+		-t backlite-agent \
 		docker/agent/
 
 docker-agent-build-local:
-	$(DOCKER) build -t backflow-agent docker/agent/
+	$(DOCKER) build -t backlite-agent docker/agent/
 
 docker-reader-build:
 	$(DOCKER) buildx build \
 		--platform linux/amd64,linux/arm64 \
-		-t backflow-reader \
+		-t backlite-reader \
 		docker/reader/
 
 docker-reader-build-local:
-	$(DOCKER) build -t backflow-reader docker/reader/
+	$(DOCKER) build -t backlite-reader docker/reader/
 
 docker-server-build:
 	$(DOCKER) buildx build \
 		--platform linux/amd64,linux/arm64 \
-		-t backflow-server \
+		-t backlite-server \
 		-f docker/server/Dockerfile .
 
 docker-server-build-local:
-	$(DOCKER) build -t backflow-server -f docker/server/Dockerfile .
+	$(DOCKER) build -t backlite-server -f docker/server/Dockerfile .
 
 DB_QUERY = @$(ENV); sqlite3 -json "$$BACKFLOW_DATABASE_PATH"
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Backflow
+# Backlite
 
 Agent orchestrator that runs coding agents (Claude Code or Codex) in ephemeral containers. POST a task (repo + prompt), get back a branch with commits and a PR. The current runtime is local Docker plus a local SQLite database.
 
@@ -13,13 +13,15 @@ Also supports a `read` task mode that runs a dedicated reader image against a UR
 
 ## Local Development
 
+For a from-scratch single-host setup, see [docs/self-hosting.md](docs/self-hosting.md).
+
 ```bash
 cp .env.example .env
 # Edit .env — at minimum set BACKFLOW_DATABASE_PATH, ANTHROPIC_API_KEY, and GITHUB_TOKEN
 ```
 
 ```bash
-make build          # Compile to bin/backflow
+make build          # Compile to bin/backlite
 make run            # Build + run (auto-sources .env)
 make test           # Run all tests with -tags nocontainers (no cache)
 make lint           # go vet
@@ -204,7 +206,7 @@ make docker-server-build-local   # Single-arch server image
 make docker-server-build         # Multi-arch buildx
 ```
 
-Backflow runs agent containers directly against the local Docker daemon; there is no remote orchestration runtime. A legacy `make teardown-aws` target exists to clean up AWS resources from older deploys — see `scripts/teardown-aws.sh` (dry-run by default; pass `ARGS="--yes"` to actually delete).
+Backlite runs agent containers directly against the local Docker daemon; there is no remote orchestration runtime. A legacy `make teardown-aws` target exists to clean up AWS resources from older deploys — see `scripts/teardown-aws.sh` (dry-run by default; pass `ARGS="--yes"` to actually delete).
 
 ## Configuration
 
@@ -229,7 +231,7 @@ All config via environment variables or `.env` file. See `.env.example` for the 
 | `BACKFLOW_DEFAULT_READ_MAX_BUDGET` | Budget cap for reading tasks |
 | `BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC` | Runtime cap for reading tasks |
 | `BACKFLOW_DEFAULT_READ_MAX_TURNS` | Max turns for reading tasks |
-| `BACKFLOW_INTERNAL_API_BASE_URL` | Optional override for the Backflow API base URL that reader containers use for duplicate/similarity lookups |
+| `BACKFLOW_INTERNAL_API_BASE_URL` | Optional override for the Backlite API base URL that reader containers use for duplicate/similarity lookups |
 
 ### Agent Defaults
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,11 +1,11 @@
 openapi: "3.0.3"
 info:
-  title: Backflow API
+  title: Backlite API
   version: "1.0.0"
   description: >
-    Backflow runs coding agents (Claude Code or Codex) in ephemeral containers.
-    Tasks come in via REST API; the orchestrator provisions infrastructure, runs
-    agents, and cleans up.
+    Backlite is a self-hostable Backlite fork that runs coding agents (Claude
+    Code or Codex) in ephemeral local Docker containers. Tasks come in via REST
+    API; the orchestrator runs agents, persists artifacts, and cleans up.
 
 servers:
   - url: http://localhost:8080
@@ -633,7 +633,7 @@ components:
 
     Task:
       type: object
-      description: A coding or review task managed by the Backflow orchestrator.
+      description: A coding or review task managed by the Backlite orchestrator.
       required:
         - id
         - status
@@ -687,7 +687,7 @@ components:
         agent_image:
           type: string
           description: Docker image used by the orchestrator for this task (reader image for read mode, default agent image otherwise).
-          example: "backflow-agent:v1"
+          example: "backlite-agent:v1"
         force:
           type: boolean
           description: For read-mode tasks, signals the agent to skip duplicate-detection and the completion handler to upsert instead of insert. No effect for code/review tasks.

--- a/cmd/backlite/main.go
+++ b/cmd/backlite/main.go
@@ -14,15 +14,15 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
-	"github.com/backflow-labs/backflow/internal/api"
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/debug"
-	"github.com/backflow-labs/backflow/internal/embeddings"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/orchestrator"
-	orchdocker "github.com/backflow-labs/backflow/internal/orchestrator/docker"
-	"github.com/backflow-labs/backflow/internal/orchestrator/outputs"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/api"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/debug"
+	"github.com/brian-bell/backlite/internal/embeddings"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/orchestrator"
+	orchdocker "github.com/brian-bell/backlite/internal/orchestrator/docker"
+	"github.com/brian-bell/backlite/internal/orchestrator/outputs"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 const (

--- a/cmd/backlite/main_test.go
+++ b/cmd/backlite/main_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 func TestSetupLogger_StderrOnly(t *testing.T) {

--- a/docker/agent/Dockerfile
+++ b/docker/agent/Dockerfile
@@ -37,8 +37,8 @@ USER agent
 WORKDIR /home/agent
 
 # Configure git
-RUN git config --global user.name "backflow-agent" \
-    && git config --global user.email "backflow-agent@noreply.github.com" \
+RUN git config --global user.name "backlite-agent" \
+    && git config --global user.email "backlite-agent@noreply.github.com" \
     && git config --global init.defaultBranch main
 
 COPY --chown=agent:agent entrypoint.sh status_writer.sh /home/agent/

--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -318,7 +318,7 @@ GIT_INSTRUCTIONS="
 
 After completing the coding task, you MUST do the following git operations:
 
-1. Create a new branch with a descriptive name prefixed with 'backflow/' (e.g. backflow/fix-auth-bug).
+1. Create a new branch with a descriptive name prefixed with 'backlite/' (e.g. backlite/fix-auth-bug).
 2. Stage and commit all your changes with a descriptive commit message.
 3. Push your branch to origin."
 
@@ -326,14 +326,14 @@ if [ "$CREATE_PR" = "true" ]; then
     GIT_INSTRUCTIONS="${GIT_INSTRUCTIONS}
 4. Create a pull request using the gh CLI:
    - Base branch: ${TARGET_BRANCH}
-   - Head branch: your new backflow/ branch"
+   - Head branch: your new backlite/ branch"
 
     if [ -n "$PR_TITLE" ]; then
         GIT_INSTRUCTIONS="${GIT_INSTRUCTIONS}
    - Title: ${PR_TITLE}"
     else
         GIT_INSTRUCTIONS="${GIT_INSTRUCTIONS}
-   - Title: [backflow] <generate a concise, descriptive title based on the changes you made>"
+   - Title: [backlite] <generate a concise, descriptive title based on the changes you made>"
     fi
 
     if [ -n "$PR_BODY" ]; then
@@ -516,7 +516,7 @@ if [ -n "$PR_URL" ]; then
 
     QUOTED_PROMPT=$(echo "$PROMPT" | sed 's/^/> /')
 
-    COMMENT_BODY="## Backflow Task
+    COMMENT_BODY="## Backlite Task
 
 ${QUOTED_PROMPT}
 

--- a/docker/reader/read-lookup.sh
+++ b/docker/reader/read-lookup.sh
@@ -26,12 +26,12 @@ fi
 RESPONSE=$(curl -fsS \
     "${AUTH_ARGS[@]}" \
     "${BACKFLOW_API_BASE_URL}/api/v1/readings/lookup?url=${ENCODED}") || {
-    echo "read-lookup: Backflow API request failed" >&2
+    echo "read-lookup: Backlite API request failed" >&2
     exit 1
 }
 
 if ! printf '%s' "$RESPONSE" | jq -e '.data | type == "array"' >/dev/null 2>&1; then
-    echo "read-lookup: unexpected response from Backflow API: $RESPONSE" >&2
+    echo "read-lookup: unexpected response from Backlite API: $RESPONSE" >&2
     exit 1
 fi
 

--- a/docker/reader/read-similar.sh
+++ b/docker/reader/read-similar.sh
@@ -46,12 +46,12 @@ RESPONSE=$(curl -fsS \
     -H "Content-Type: application/json" \
     -d "$REQUEST_BODY" \
     "${BACKFLOW_API_BASE_URL}/api/v1/readings/similar") || {
-    echo "read-similar: Backflow similarity request failed" >&2
+    echo "read-similar: Backlite similarity request failed" >&2
     exit 1
 }
 
 if ! printf '%s' "$RESPONSE" | jq -e '.data | type == "array"' >/dev/null 2>&1; then
-    echo "read-similar: unexpected response from Backflow API: $RESPONSE" >&2
+    echo "read-similar: unexpected response from Backlite API: $RESPONSE" >&2
     exit 1
 fi
 

--- a/docker/reader/reader-entrypoint.sh
+++ b/docker/reader/reader-entrypoint.sh
@@ -67,7 +67,7 @@ if [ "$HARNESS" = "codex" ]; then
     echo "$OPENAI_API_KEY" | codex login --with-api-key
 fi
 
-# --- Backflow API + OpenAI access for helper scripts ---
+# --- Backlite API + OpenAI access for helper scripts ---
 if [ -z "${BACKFLOW_API_BASE_URL:-}" ]; then
     echo "WARNING: BACKFLOW_API_BASE_URL is not set; read-lookup.sh and read-similar.sh will fail." >&2
 fi

--- a/docker/reader/test_reader_e2e.sh
+++ b/docker/reader/test_reader_e2e.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # End-to-end smoke test for the reader image. Hits real OpenAI + Anthropic APIs
-# plus a running Backflow server, so it reads credentials from the repo's .env file.
+# plus a running Backlite server, so it reads credentials from the repo's .env file.
 # Required keys in .env:
 #   OPENAI_API_KEY, ANTHROPIC_API_KEY, BACKFLOW_INTERNAL_API_BASE_URL
 
@@ -28,20 +28,20 @@ done
 
 # Embedding (real OpenAI call)
 docker run --rm -e OPENAI_API_KEY="$OPENAI_API_KEY" \
-  --entrypoint /home/agent/read-embed.sh backflow-reader \
+  --entrypoint /home/agent/read-embed.sh backlite-reader \
   "hello world" | jq 'length'   # ~1536
 
-# Exact-URL lookup (real Backflow API call)
+# Exact-URL lookup (real Backlite API call)
 docker run --rm \
   -e BACKFLOW_API_BASE_URL="$BACKFLOW_INTERNAL_API_BASE_URL" \
-  --entrypoint /home/agent/read-lookup.sh backflow-reader \
+  --entrypoint /home/agent/read-lookup.sh backlite-reader \
   "https://example.com/non-existent" | jq .   # []
 
-# Similarity search (real OpenAI + Backflow API calls)
+# Similarity search (real OpenAI + Backlite API calls)
 docker run --rm \
   -e OPENAI_API_KEY="$OPENAI_API_KEY" \
   -e BACKFLOW_API_BASE_URL="$BACKFLOW_INTERNAL_API_BASE_URL" \
-  --entrypoint /home/agent/read-similar.sh backflow-reader \
+  --entrypoint /home/agent/read-similar.sh backlite-reader \
   "attention mechanisms in transformers" 3 | jq .
 
 # Full entrypoint run (real ANTHROPIC_API_KEY)
@@ -50,6 +50,6 @@ docker run --rm \
   -e ANTHROPIC_API_KEY="$ANTHROPIC_API_KEY" \
   -e OPENAI_API_KEY="$OPENAI_API_KEY" \
   -e BACKFLOW_API_BASE_URL="$BACKFLOW_INTERNAL_API_BASE_URL" \
-  backflow-reader 2>&1 | tail -20
+  backlite-reader 2>&1 | tail -20
 # Expect: a single `BACKFLOW_STATUS_JSON:{...}` line with
 # `.task_mode == "read"` and a populated `.reading` object.

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -4,11 +4,11 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -trimpath -o /backflow ./cmd/backflow
+RUN CGO_ENABLED=0 go build -trimpath -o /backlite ./cmd/backlite
 
 FROM gcr.io/distroless/static-debian12
 
-COPY --from=builder /backflow /backflow
+COPY --from=builder /backlite /backlite
 COPY --from=builder /src/migrations /migrations
 
-ENTRYPOINT ["/backflow"]
+ENTRYPOINT ["/backlite"]

--- a/docs/adrs/001-hnsw-over-ivfflat.md
+++ b/docs/adrs/001-hnsw-over-ivfflat.md
@@ -7,7 +7,7 @@ Superseded by the SQLite migration
 ## Context
 
 This ADR described the former Postgres + pgvector design for `readings` similarity search.
-Backflow now stores embeddings as JSON text in SQLite and ranks cosine similarity in Go, so
+Backlite now stores embeddings as JSON text in SQLite and ranks cosine similarity in Go, so
 the pgvector index decision is no longer part of the active architecture.
 
 ## Historical decision

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,6 +1,6 @@
 # Database Schema
 
-Backflow uses a local SQLite database. Migrations are managed by [goose](https://github.com/pressly/goose) and live in `migrations/`. The database path is set via `BACKFLOW_DATABASE_PATH`.
+Backlite uses a local SQLite database. Migrations are managed by [goose](https://github.com/pressly/goose) and live in `migrations/`. The database path is set via `BACKFLOW_DATABASE_PATH`.
 
 ## Tables
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,125 @@
+# Self-Hosting Backlite
+
+This guide takes a fresh checkout from zero to a running Backlite task on a single Docker host.
+
+Backlite keeps the upstream `BACKFLOW_*` env var prefix for compatibility, even though the module, binary, and Docker image names now use `backlite`.
+
+## Prerequisites
+
+- Go 1.25+
+- Docker with a running daemon
+- SQLite
+- `jq`
+- A GitHub token that can clone the target repos and open PRs
+- An Anthropic API key for `claude_code`, or an OpenAI API key for `codex`
+
+If you want `task_mode=read`, set `OPENAI_API_KEY` as well. Reader containers call Backlite's own API for duplicate and similarity lookups.
+
+## 1. Build the Images
+
+From the repo root:
+
+```bash
+make docker-agent-build-local
+make docker-reader-build-local   # only if you want task_mode=read
+```
+
+If you plan to run the agent or reader from a registry tag instead of the local defaults, set `BACKFLOW_AGENT_IMAGE` and `BACKFLOW_READER_IMAGE` accordingly in `.env`.
+
+## 2. Configure `.env`
+
+Start from the example file:
+
+```bash
+cp .env.example .env
+```
+
+For a code/review-only deployment, set at least:
+
+```bash
+ANTHROPIC_API_KEY=...
+GITHUB_TOKEN=...
+BACKFLOW_DATABASE_PATH=/srv/backlite/backlite.db
+BACKFLOW_AGENT_IMAGE=backlite-agent
+BACKFLOW_DATA_DIR=/srv/backlite/data
+```
+
+For reader mode, also set:
+
+```bash
+OPENAI_API_KEY=...
+BACKFLOW_READER_IMAGE=backlite-reader
+BACKFLOW_DEFAULT_READ_MAX_BUDGET=<budget-usd>
+BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC=<seconds>
+BACKFLOW_DEFAULT_READ_MAX_TURNS=<turns>
+# Optional when the default host-gateway URL does not work for reader containers:
+# BACKFLOW_INTERNAL_API_BASE_URL=http://host.docker.internal:8080
+```
+
+Optional webhook notifier:
+
+```bash
+BACKFLOW_WEBHOOK_URL=https://your-webhook-endpoint.example
+BACKFLOW_WEBHOOK_EVENTS=task.completed,task.failed,task.needs_input
+```
+
+Backlite auto-runs SQLite migrations on startup. It writes the application database at `BACKFLOW_DATABASE_PATH` and completed task logs and metadata under `BACKFLOW_DATA_DIR/tasks/<task-id>/`. Choose paths on persistent storage.
+
+See `internal/config/config.go` for the full env surface and current defaults.
+
+## 3. Start the Server
+
+Use `make run` so the command sources `.env` before starting the binary:
+
+```bash
+make run
+```
+
+The server process needs access to the Docker socket because it launches agent containers locally. Running the server binary directly on the Docker host is the supported self-hosting path.
+
+## 4. Smoke Test the Deployment
+
+Check health:
+
+```bash
+curl -s http://localhost:8080/health
+```
+
+Submit a code task:
+
+```bash
+./scripts/create-task.sh "Fix the login bug in https://github.com/owner/repo"
+```
+
+Submit a review task:
+
+```bash
+./scripts/review-pr.sh https://github.com/owner/repo/pull/42
+```
+
+Submit a read task:
+
+```bash
+./scripts/read-url.sh https://example.com/article
+```
+
+Inspect the resulting artifacts:
+
+```bash
+curl -s http://localhost:8080/api/v1/tasks/<task-id>/output
+curl -s http://localhost:8080/api/v1/tasks/<task-id>/output.json
+ls "$BACKFLOW_DATA_DIR/tasks/<task-id>/"
+```
+
+## 5. Operational Notes
+
+- Backlite is local-Docker-only. There is no alternate cloud runtime path.
+- The notifier is webhook-only.
+- The synthetic `instances` row in SQLite tracks local Docker capacity; it is not a cloud instance inventory.
+- `save_agent_output=false` disables the filesystem artifact write for a task.
+
+## Related Docs
+
+- [README.md](../README.md)
+- [CLAUDE.md](../CLAUDE.md)
+- [docs/schema.md](./schema.md)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/backflow-labs/backflow
+module github.com/brian-bell/backlite
 
 go 1.25.0
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 const hasKeysCacheTTL = 30 * time.Second

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -12,13 +12,13 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
-// taskIDPattern matches Backflow task IDs: `bf_` prefix + 26-char ULID body.
+// taskIDPattern matches Backlite task IDs: `bf_` prefix + 26-char ULID body.
 // Mirrors the OpenAPI schema pattern. Used to reject malformed IDs before
 // they reach code paths (like filesystem joins) where an unsafe value could
 // be harmful.

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -11,10 +11,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 func newTestStore(t *testing.T) *store.SQLiteStore {
@@ -259,7 +259,7 @@ func TestCreateReadTask_ViaPOSTTasks(t *testing.T) {
 
 	cfg := &config.Config{
 		AnthropicAPIKey:       "sk-test",
-		ReaderImage:           "backflow-reader:v1",
+		ReaderImage:           "backlite-reader:v1",
 		DefaultHarness:        "claude_code",
 		DefaultClaudeModel:    "claude-sonnet-4-6",
 		DefaultCodexModel:     "gpt-5.4",
@@ -301,7 +301,7 @@ func TestCreateReadTask_ViaPOSTTasks(t *testing.T) {
 	if !resp.Data.Force {
 		t.Error("force = false, want true")
 	}
-	if resp.Data.AgentImage != "backflow-reader:v1" {
+	if resp.Data.AgentImage != "backlite-reader:v1" {
 		t.Errorf("agent_image = %q, want reader image", resp.Data.AgentImage)
 	}
 	if resp.Data.CreatePR {
@@ -450,7 +450,7 @@ func TestDeleteTask_EmitsCancelledEvent(t *testing.T) {
 // TestLookupReading_EmptyResultReturnsDataArray locks in the JSON envelope
 // shape on a miss. The reader container's read-lookup.sh requires
 // `.data | type == "array"`; if `data` is ever omitted on empty results the
-// script fails with "unexpected response from Backflow API".
+// script fails with "unexpected response from Backlite API".
 func TestLookupReading_EmptyResultReturnsDataArray(t *testing.T) {
 	srv := testServer(t)
 

--- a/internal/api/helpers_test.go
+++ b/internal/api/helpers_test.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 
-	"github.com/backflow-labs/backflow/internal/notify"
+	"github.com/brian-bell/backlite/internal/notify"
 )
 
 type noopLogFetcher struct{}

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 func TestAPIAuth_RequiresBearerToken(t *testing.T) {
@@ -280,7 +280,7 @@ func TestAPIHealthAccessible(t *testing.T) {
 func TestRestrictAPIEnvVar_NoLongerBlocksAPI(t *testing.T) {
 	t.Setenv("BACKFLOW_RESTRICT_API", "true")
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-	t.Setenv("BACKFLOW_DATABASE_PATH", "/tmp/backflow-test.db")
+	t.Setenv("BACKFLOW_DATABASE_PATH", "/tmp/backlite-test.db")
 
 	cfg, err := config.Load()
 	if err != nil {

--- a/internal/api/output_test.go
+++ b/internal/api/output_test.go
@@ -11,9 +11,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // outputTestServer creates a server rooted at a temp DataDir and returns

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,9 +4,9 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 func NewServer(s store.Store, cfg *config.Config, logs LogFetcher, bus notify.Emitter) chi.Router {

--- a/internal/api/task_actions.go
+++ b/internal/api/task_actions.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // CancelTask validates the task is in a cancellable state, cancels it in the store,

--- a/internal/api/task_actions_test.go
+++ b/internal/api/task_actions_test.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // taskActionStore implements the subset of store.Store needed by CancelTask and RetryTask.

--- a/internal/api/task_creator.go
+++ b/internal/api/task_creator.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/oklog/ulid/v2"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // ErrStoreFailure is returned when the store fails to persist a task.

--- a/internal/api/task_creator_test.go
+++ b/internal/api/task_creator_test.go
@@ -6,10 +6,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // mockStore implements store.Store for unit tests that need a failing CreateTask.
@@ -78,8 +78,8 @@ func (c *capturingEmitter) Emit(e notify.Event) { c.events = append(c.events, e)
 // the reader image and read-mode caps that TaskDefaults("read") reads from.
 func readTestConfig() *config.Config {
 	return &config.Config{
-		AgentImage:            "backflow-agent",
-		ReaderImage:           "backflow-reader:v1",
+		AgentImage:            "backlite-agent",
+		ReaderImage:           "backlite-reader:v1",
 		DefaultHarness:        "claude_code",
 		DefaultClaudeModel:    "claude-sonnet-4-6",
 		DefaultCodexModel:     "gpt-5.4",
@@ -103,8 +103,8 @@ func TestNewReadTask_SetsReadModeAndReaderImage(t *testing.T) {
 	if task.TaskMode != models.TaskModeRead {
 		t.Errorf("TaskMode = %q, want %q", task.TaskMode, models.TaskModeRead)
 	}
-	if task.AgentImage != "backflow-reader:v1" {
-		t.Errorf("AgentImage = %q, want %q", task.AgentImage, "backflow-reader:v1")
+	if task.AgentImage != "backlite-reader:v1" {
+		t.Errorf("AgentImage = %q, want %q", task.AgentImage, "backlite-reader:v1")
 	}
 	if task.CreatePR {
 		t.Error("CreatePR = true, want false for read mode")
@@ -218,7 +218,7 @@ func TestNewTask_TaskModeRead_DispatchesToNewReadTask(t *testing.T) {
 	if task.TaskMode != models.TaskModeRead {
 		t.Errorf("TaskMode = %q, want %q", task.TaskMode, models.TaskModeRead)
 	}
-	if task.AgentImage != "backflow-reader:v1" {
+	if task.AgentImage != "backlite-reader:v1" {
 		t.Errorf("AgentImage = %q, want reader image", task.AgentImage)
 	}
 	if task.CreatePR {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,7 +85,7 @@ func Load() (*Config, error) {
 		ContainersPerInst:     envInt("BACKFLOW_CONTAINERS_PER_INSTANCE", 1),
 		ContainerCPUs:         envInt("BACKFLOW_CONTAINER_CPUS", 2),
 		ContainerMemGB:        envInt("BACKFLOW_CONTAINER_MEMORY_GB", 8),
-		AgentImage:            envOr("BACKFLOW_AGENT_IMAGE", "backflow-agent"),
+		AgentImage:            envOr("BACKFLOW_AGENT_IMAGE", "backlite-agent"),
 		ReaderImage:           os.Getenv("BACKFLOW_READER_IMAGE"),
 		DefaultHarness:        envOr("BACKFLOW_DEFAULT_HARNESS", "claude_code"),
 		DefaultClaudeModel:    envOr("BACKFLOW_DEFAULT_CLAUDE_MODEL", "claude-opus-4-7"),
@@ -102,7 +102,7 @@ func Load() (*Config, error) {
 		GitHubToken:           os.Getenv("GITHUB_TOKEN"),
 		WebhookURL:            os.Getenv("BACKFLOW_WEBHOOK_URL"),
 		LogFile:               os.Getenv("BACKFLOW_LOG_FILE"),
-		DatabasePath:          envOr("BACKFLOW_DATABASE_PATH", "./backflow.db"),
+		DatabasePath:          envOr("BACKFLOW_DATABASE_PATH", "./backlite.db"),
 		MaxUserRetries:        envInt("BACKFLOW_MAX_USER_RETRIES", 2),
 		PollInterval:          time.Duration(envInt("BACKFLOW_POLL_INTERVAL_SEC", 5)) * time.Second,
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,7 +9,7 @@ import (
 func setBaseEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("ANTHROPIC_API_KEY", "test-key")
-	t.Setenv("BACKFLOW_DATABASE_PATH", "/tmp/backflow-test.db")
+	t.Setenv("BACKFLOW_DATABASE_PATH", "/tmp/backlite-test.db")
 }
 
 func TestLoad_UsesDefaultDatabasePath(t *testing.T) {
@@ -20,8 +20,8 @@ func TestLoad_UsesDefaultDatabasePath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() returned error: %v", err)
 	}
-	if cfg.DatabasePath != "./backflow.db" {
-		t.Fatalf("DatabasePath = %q, want ./backflow.db", cfg.DatabasePath)
+	if cfg.DatabasePath != "./backlite.db" {
+		t.Fatalf("DatabasePath = %q, want ./backlite.db", cfg.DatabasePath)
 	}
 }
 
@@ -68,14 +68,14 @@ func TestLoad_DataDir_Default(t *testing.T) {
 
 func TestLoad_DataDir_Set(t *testing.T) {
 	setBaseEnv(t)
-	t.Setenv("BACKFLOW_DATA_DIR", "/var/lib/backflow")
+	t.Setenv("BACKFLOW_DATA_DIR", "/var/lib/backlite")
 
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load() returned error: %v", err)
 	}
-	if cfg.DataDir != "/var/lib/backflow" {
-		t.Errorf("DataDir = %q, want %q", cfg.DataDir, "/var/lib/backflow")
+	if cfg.DataDir != "/var/lib/backlite" {
+		t.Errorf("DataDir = %q, want %q", cfg.DataDir, "/var/lib/backlite")
 	}
 }
 
@@ -93,20 +93,20 @@ func TestLoad_LogFile_DefaultEmpty(t *testing.T) {
 
 func TestLoad_LogFile_Set(t *testing.T) {
 	setBaseEnv(t)
-	t.Setenv("BACKFLOW_LOG_FILE", "/tmp/backflow.log")
+	t.Setenv("BACKFLOW_LOG_FILE", "/tmp/backlite.log")
 
 	cfg, err := Load()
 	if err != nil {
 		t.Fatalf("Load() returned error: %v", err)
 	}
-	if cfg.LogFile != "/tmp/backflow.log" {
-		t.Errorf("LogFile = %q, want %q", cfg.LogFile, "/tmp/backflow.log")
+	if cfg.LogFile != "/tmp/backlite.log" {
+		t.Errorf("LogFile = %q, want %q", cfg.LogFile, "/tmp/backlite.log")
 	}
 }
 
 func TestLoad_ReaderConfig(t *testing.T) {
 	setBaseEnv(t)
-	t.Setenv("BACKFLOW_READER_IMAGE", "backflow-reader:v1")
+	t.Setenv("BACKFLOW_READER_IMAGE", "backlite-reader:v1")
 	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_BUDGET", "0.5")
 	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC", "300")
 	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_TURNS", "20")
@@ -116,8 +116,8 @@ func TestLoad_ReaderConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() returned error: %v", err)
 	}
-	if cfg.ReaderImage != "backflow-reader:v1" {
-		t.Errorf("ReaderImage = %q, want %q", cfg.ReaderImage, "backflow-reader:v1")
+	if cfg.ReaderImage != "backlite-reader:v1" {
+		t.Errorf("ReaderImage = %q, want %q", cfg.ReaderImage, "backlite-reader:v1")
 	}
 	if cfg.DefaultReadMaxBudget != 0.5 {
 		t.Errorf("DefaultReadMaxBudget = %v, want %v", cfg.DefaultReadMaxBudget, 0.5)
@@ -160,7 +160,7 @@ func TestLoad_ReaderConfig_UnsetDefaults(t *testing.T) {
 func setReaderEnv(t *testing.T) {
 	t.Helper()
 	setBaseEnv(t)
-	t.Setenv("BACKFLOW_READER_IMAGE", "backflow-reader:v1")
+	t.Setenv("BACKFLOW_READER_IMAGE", "backlite-reader:v1")
 	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_BUDGET", "0.5")
 	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC", "300")
 	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_TURNS", "20")

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -1,6 +1,6 @@
 package config
 
-import "github.com/backflow-labs/backflow/internal/models"
+import "github.com/brian-bell/backlite/internal/models"
 
 // TaskDefaults holds resolved default values for new tasks.
 type TaskDefaults struct {

--- a/internal/config/defaults_test.go
+++ b/internal/config/defaults_test.go
@@ -4,13 +4,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/models"
+	"github.com/brian-bell/backlite/internal/models"
 )
 
 func testConfig() *Config {
 	return &Config{
-		AgentImage:            "backflow-agent",
-		ReaderImage:           "backflow-reader",
+		AgentImage:            "backlite-agent",
+		ReaderImage:           "backlite-reader",
 		DefaultHarness:        "claude_code",
 		DefaultClaudeModel:    "claude-sonnet-4-6",
 		DefaultCodexModel:     "gpt-5.4",
@@ -83,8 +83,8 @@ func TestTaskDefaults_ReadMode(t *testing.T) {
 	cfg := testConfig()
 	d := cfg.TaskDefaults(models.TaskModeRead)
 
-	if d.AgentImage != "backflow-reader" {
-		t.Errorf("AgentImage = %q, want %q", d.AgentImage, "backflow-reader")
+	if d.AgentImage != "backlite-reader" {
+		t.Errorf("AgentImage = %q, want %q", d.AgentImage, "backlite-reader")
 	}
 	if d.MaxBudgetUSD != 0.5 {
 		t.Errorf("MaxBudgetUSD = %v, want %v (read cap)", d.MaxBudgetUSD, 0.5)
@@ -103,8 +103,8 @@ func TestTaskDefaults_ReadMode(t *testing.T) {
 func TestTaskDefaults_CodeMode_AgentImage(t *testing.T) {
 	cfg := testConfig()
 	d := cfg.TaskDefaults(models.TaskModeCode)
-	if d.AgentImage != "backflow-agent" {
-		t.Errorf("AgentImage = %q, want %q in code mode", d.AgentImage, "backflow-agent")
+	if d.AgentImage != "backlite-agent" {
+		t.Errorf("AgentImage = %q, want %q in code mode", d.AgentImage, "backlite-agent")
 	}
 }
 
@@ -252,8 +252,8 @@ func TestApply_FillsAgentImage(t *testing.T) {
 
 	d.Apply(task, nil)
 
-	if task.AgentImage != "backflow-reader" {
-		t.Errorf("AgentImage = %q, want %q (from read defaults)", task.AgentImage, "backflow-reader")
+	if task.AgentImage != "backlite-reader" {
+		t.Errorf("AgentImage = %q, want %q (from read defaults)", task.AgentImage, "backlite-reader")
 	}
 }
 

--- a/internal/debug/stats.go
+++ b/internal/debug/stats.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // PoolStatter is implemented by store backends that can report connection pool

--- a/internal/debug/stats_test.go
+++ b/internal/debug/stats_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 type mockPoolStatter struct{}

--- a/internal/models/task_test.go
+++ b/internal/models/task_test.go
@@ -235,12 +235,12 @@ func TestCreateTaskRequestValidation(t *testing.T) {
 }
 
 func TestTaskAgentImageJSON(t *testing.T) {
-	task := Task{ID: "bf_test", AgentImage: "backflow-reader:v1"}
+	task := Task{ID: "bf_test", AgentImage: "backlite-reader:v1"}
 	data, err := json.Marshal(task)
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
 	}
-	if !strings.Contains(string(data), `"agent_image":"backflow-reader:v1"`) {
+	if !strings.Contains(string(data), `"agent_image":"backlite-reader:v1"`) {
 		t.Errorf("missing agent_image in marshaled task: %s", data)
 	}
 
@@ -248,8 +248,8 @@ func TestTaskAgentImageJSON(t *testing.T) {
 	if err := json.Unmarshal(data, &got); err != nil {
 		t.Fatalf("Unmarshal: %v", err)
 	}
-	if got.AgentImage != "backflow-reader:v1" {
-		t.Errorf("AgentImage = %q, want %q", got.AgentImage, "backflow-reader:v1")
+	if got.AgentImage != "backlite-reader:v1" {
+		t.Errorf("AgentImage = %q, want %q", got.AgentImage, "backlite-reader:v1")
 	}
 }
 

--- a/internal/notify/bus_test.go
+++ b/internal/notify/bus_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/models"
+	"github.com/brian-bell/backlite/internal/models"
 	"github.com/rs/zerolog/log"
 )
 

--- a/internal/notify/event.go
+++ b/internal/notify/event.go
@@ -3,7 +3,7 @@ package notify
 import (
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/models"
+	"github.com/brian-bell/backlite/internal/models"
 )
 
 // EventOption is a functional option for NewEvent.

--- a/internal/notify/webhook.go
+++ b/internal/notify/webhook.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/models"
+	"github.com/brian-bell/backlite/internal/models"
 	"github.com/rs/zerolog/log"
 )
 
@@ -141,7 +141,7 @@ func (w *WebhookNotifier) Notify(event Event) error {
 			return fmt.Errorf("create request: %w", err)
 		}
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("User-Agent", "backflow-webhook/1.0")
+		req.Header.Set("User-Agent", "backlite-webhook/1.0")
 
 		resp, err := w.httpClient.Do(req)
 		if err != nil {

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // dispatchPending finds pending tasks and dispatches them to available instances,

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
 )
 
 func TestFindAvailableInstance_ReturnsInstanceWithCapacity(t *testing.T) {
@@ -397,7 +397,7 @@ func TestDispatch_ReadTask_OrchestratorMissingReaderImage_Fails(t *testing.T) {
 		Status:     models.TaskStatusPending,
 		TaskMode:   models.TaskModeRead,
 		Prompt:     "https://example.com/post",
-		AgentImage: "backflow-reader", // set by the creating orchestrator
+		AgentImage: "backlite-reader", // set by the creating orchestrator
 	}
 	s.CreateTask(context.Background(), task)
 
@@ -495,7 +495,7 @@ func TestDispatch_ReadDuplicate_NonForce_FailsWithoutContainer(t *testing.T) {
 	}
 	embedder := &mockEmbedder{}
 	o := newTestOrchestrator(s, bus, withDocker(mock), withEmbedder(embedder))
-	o.config.ReaderImage = "backflow-reader"
+	o.config.ReaderImage = "backlite-reader"
 
 	task, _ = s.GetTask(context.Background(), "bf_read_dup_noforce")
 	err := o.dispatch(context.Background(), task)
@@ -574,7 +574,7 @@ func TestDispatch_ReadDuplicate_Force_ProceedsNormally(t *testing.T) {
 		inspectResults: map[string]ContainerStatus{},
 	}
 	o := newTestOrchestrator(s, bus, withDocker(mock), withEmbedder(&mockEmbedder{}))
-	o.config.ReaderImage = "backflow-reader"
+	o.config.ReaderImage = "backlite-reader"
 
 	task, _ = s.GetTask(context.Background(), "bf_read_dup_force")
 	err := o.dispatch(context.Background(), task)
@@ -624,7 +624,7 @@ func TestDispatch_ReadDuplicate_LookupError_ReturnsError(t *testing.T) {
 		inspectResults: map[string]ContainerStatus{},
 	}
 	o := newTestOrchestrator(s, bus, withDocker(mock), withEmbedder(&mockEmbedder{}))
-	o.config.ReaderImage = "backflow-reader"
+	o.config.ReaderImage = "backlite-reader"
 
 	task, _ = s.GetTask(context.Background(), "bf_read_dup_lookuperr")
 	err := o.dispatch(context.Background(), task)

--- a/internal/orchestrator/docker/docker.go
+++ b/internal/orchestrator/docker/docker.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/orchestrator"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/orchestrator"
 )
 
 // Manager manages agent containers on the local Docker host.
@@ -196,7 +196,7 @@ func writeEnvFile(pairs []string) (string, error) {
 	if len(pairs) == 0 {
 		return "", nil
 	}
-	f, err := os.CreateTemp("", "backflow-env-*")
+	f, err := os.CreateTemp("", "backlite-env-*")
 	if err != nil {
 		return "", err
 	}

--- a/internal/orchestrator/docker/docker_test.go
+++ b/internal/orchestrator/docker/docker_test.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/orchestrator"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/orchestrator"
 )
 
 // Compile-time check: *Manager must satisfy orchestrator.Runner.
@@ -184,7 +184,7 @@ func TestBuildRunCommand(t *testing.T) {
 		AnthropicAPIKey: "sk-test",
 		ContainerCPUs:   2,
 		ContainerMemGB:  8,
-		AgentImage:      "backflow-agent",
+		AgentImage:      "backlite-agent",
 	}
 	dm := NewManager(cfg)
 
@@ -199,7 +199,7 @@ func TestBuildRunCommand(t *testing.T) {
 	if !strings.HasPrefix(cmd, "docker run -d --cpus=2 --memory=8g") {
 		t.Errorf("unexpected command prefix: %s", cmd)
 	}
-	if !strings.HasSuffix(cmd, "backflow-agent") {
+	if !strings.HasSuffix(cmd, "backlite-agent") {
 		t.Errorf("command should end with image name, got: %s", cmd)
 	}
 	if !strings.Contains(cmd, "-e TASK_ID=bf_01ABC") {
@@ -214,7 +214,7 @@ func TestBuildRunCommand_WithEnvFile(t *testing.T) {
 	cfg := &config.Config{
 		ContainerCPUs:  2,
 		ContainerMemGB: 8,
-		AgentImage:     "backflow-agent",
+		AgentImage:     "backlite-agent",
 	}
 	dm := NewManager(cfg)
 
@@ -224,12 +224,12 @@ func TestBuildRunCommand_WithEnvFile(t *testing.T) {
 		Prompt:  "Fix bug",
 	}
 
-	cmd := dm.buildRunCommand(task, "/tmp/backflow-env-12345")
+	cmd := dm.buildRunCommand(task, "/tmp/backlite-env-12345")
 
-	if !strings.Contains(cmd, "--env-file /tmp/backflow-env-12345") {
+	if !strings.Contains(cmd, "--env-file /tmp/backlite-env-12345") {
 		t.Errorf("command should contain --env-file flag, got: %s", cmd)
 	}
-	if !strings.HasSuffix(cmd, "backflow-agent") {
+	if !strings.HasSuffix(cmd, "backlite-agent") {
 		t.Errorf("command should end with image name, got: %s", cmd)
 	}
 }
@@ -300,20 +300,20 @@ func TestBuildRunCommand_UsesTaskAgentImage(t *testing.T) {
 	cfg := &config.Config{
 		ContainerCPUs:  2,
 		ContainerMemGB: 8,
-		AgentImage:     "backflow-agent",
+		AgentImage:     "backlite-agent",
 	}
 	dm := NewManager(cfg)
 	task := &models.Task{
 		ID:         "bf_01ABC",
-		AgentImage: "backflow-reader:v1",
+		AgentImage: "backlite-reader:v1",
 	}
 
 	cmd := dm.buildRunCommand(task, "")
 
-	if !strings.HasSuffix(cmd, "backflow-reader:v1") {
+	if !strings.HasSuffix(cmd, "backlite-reader:v1") {
 		t.Errorf("command should end with task.AgentImage, got: %s", cmd)
 	}
-	if strings.HasSuffix(cmd, "backflow-agent") {
+	if strings.HasSuffix(cmd, "backlite-agent") {
 		t.Errorf("command should not fall back to cfg.AgentImage when task.AgentImage is set, got: %s", cmd)
 	}
 }
@@ -322,7 +322,7 @@ func TestBuildRunCommand_FallsBackToConfigAgentImage(t *testing.T) {
 	cfg := &config.Config{
 		ContainerCPUs:  2,
 		ContainerMemGB: 8,
-		AgentImage:     "backflow-agent",
+		AgentImage:     "backlite-agent",
 	}
 	dm := NewManager(cfg)
 	task := &models.Task{
@@ -332,7 +332,7 @@ func TestBuildRunCommand_FallsBackToConfigAgentImage(t *testing.T) {
 
 	cmd := dm.buildRunCommand(task, "")
 
-	if !strings.HasSuffix(cmd, "backflow-agent") {
+	if !strings.HasSuffix(cmd, "backlite-agent") {
 		t.Errorf("command should fall back to cfg.AgentImage when task.AgentImage is empty, got: %s", cmd)
 	}
 }
@@ -361,7 +361,7 @@ func TestBuildSecretEnvPairs(t *testing.T) {
 	}
 }
 
-func TestBuildSecretEnvPairs_IncludesBackflowAPIKey(t *testing.T) {
+func TestBuildSecretEnvPairs_IncludesBackliteAPIKey(t *testing.T) {
 	cfg := &config.Config{APIKey: "internal-secret"}
 	dm := NewManager(cfg)
 

--- a/internal/orchestrator/helpers_test.go
+++ b/internal/orchestrator/helpers_test.go
@@ -6,11 +6,11 @@ import (
 	"sync"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/embeddings"
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/embeddings"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // --- Mock store ---

--- a/internal/orchestrator/monitor.go
+++ b/internal/orchestrator/monitor.go
@@ -9,9 +9,9 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/rs/zerolog/log"
 
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // monitorCancelled cleans up tasks that were cancelled via the API while they

--- a/internal/orchestrator/monitor_test.go
+++ b/internal/orchestrator/monitor_test.go
@@ -10,9 +10,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/orchestrator/outputs"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/orchestrator/outputs"
 )
 
 func TestMonitorCancelled_DecrementsRunning(t *testing.T) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/backflow-labs/backflow/internal/config"
-	"github.com/backflow-labs/backflow/internal/embeddings"
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/embeddings"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // maxInspectFailures is the number of consecutive container inspect failures

--- a/internal/orchestrator/recovery.go
+++ b/internal/orchestrator/recovery.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/rs/zerolog/log"
 
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // recoverOnStartup transitions orphaned running/provisioning tasks to the

--- a/internal/orchestrator/recovery_test.go
+++ b/internal/orchestrator/recovery_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/models"
-	"github.com/backflow-labs/backflow/internal/notify"
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
 )
 
 func TestRecoverOnStartup_NoOrphans(t *testing.T) {

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/backflow-labs/backflow/internal/models"
+	"github.com/brian-bell/backlite/internal/models"
 )
 
 // Runner abstracts container lifecycle management on the local Docker host.

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rs/zerolog/log"
 	_ "modernc.org/sqlite"
 
-	"github.com/backflow-labs/backflow/internal/models"
+	"github.com/brian-bell/backlite/internal/models"
 )
 
 type sqliteQuerier interface {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/models"
+	"github.com/brian-bell/backlite/internal/models"
 )
 
 // sqliteTestTask creates a minimal task and inserts it.
@@ -23,7 +23,7 @@ func sqliteTestTask(t *testing.T, s *SQLiteStore) *models.Task {
 		TaskMode:  models.TaskModeCode,
 		Harness:   models.HarnessClaudeCode,
 		RepoURL:   "https://github.com/test/repo",
-		Branch:    "backflow/test",
+		Branch:    "backlite/test",
 		Prompt:    "Fix the bug",
 		Model:     "claude-sonnet-4-6",
 		CreatePR:  true,
@@ -89,11 +89,11 @@ func TestSQLite_TaskRoundTrip(t *testing.T) {
 		TaskMode:        models.TaskModeCode,
 		Harness:         models.HarnessClaudeCode,
 		RepoURL:         "https://github.com/test/repo",
-		Branch:          "backflow/test",
+		Branch:          "backlite/test",
 		TargetBranch:    "main",
 		Prompt:          "Fix the bug",
 		Model:           "claude-sonnet-4-6",
-		AgentImage:      "backflow-agent:v2",
+		AgentImage:      "backlite-agent:v2",
 		MaxBudgetUSD:    10.0,
 		MaxTurns:        200,
 		CreatePR:        true,
@@ -150,8 +150,8 @@ func TestSQLite_TaskRoundTrip(t *testing.T) {
 	if got.EnvVars["FOO"] != "bar" {
 		t.Errorf("EnvVars[FOO] = %q, want bar", got.EnvVars["FOO"])
 	}
-	if got.AgentImage != "backflow-agent:v2" {
-		t.Errorf("AgentImage = %q, want %q", got.AgentImage, "backflow-agent:v2")
+	if got.AgentImage != "backlite-agent:v2" {
+		t.Errorf("AgentImage = %q, want %q", got.AgentImage, "backlite-agent:v2")
 	}
 	if !got.CreatedAt.Equal(now) {
 		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, now)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	"github.com/backflow-labs/backflow/internal/models"
+	"github.com/brian-bell/backlite/internal/models"
 )
 
 // ErrNotFound is returned when a requested record does not exist.

--- a/scripts/build-agent-image.sh
+++ b/scripts/build-agent-image.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build and push the backflow agent Docker image (multi-arch)
+# Build and push the backlite agent Docker image (multi-arch)
 
 REGION="${AWS_REGION:-us-east-1}"
-ECR_REPO="backflow-agent"
+ECR_REPO="backlite-agent"
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 ECR_URI="${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/${ECR_REPO}"
@@ -13,7 +13,7 @@ echo "==> Authenticating with ECR..."
 aws ecr get-login-password --region "$REGION" | docker login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com"
 
 echo "==> Building multi-arch image..."
-docker buildx create --name backflow-builder --use 2>/dev/null || docker buildx use backflow-builder
+docker buildx create --name backlite-builder --use 2>/dev/null || docker buildx use backlite-builder
 
 docker buildx build \
     --platform linux/amd64,linux/arm64 \

--- a/scripts/create-task.sh
+++ b/scripts/create-task.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Create a task via the Backflow API
+# Create a task via the Backlite API
 #
 # The prompt must include a GitHub URL — the agent's prep stage infers
 # repo_url, target_branch, and task_type from the prompt text.

--- a/scripts/read-url.sh
+++ b/scripts/read-url.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Submit a URL for reading-mode summarization via the Backflow API.
+# Submit a URL for reading-mode summarization via the Backlite API.
 #
 # The reader container fetches the URL, drafts a TL;DR, and persists a row
 # in the `readings` table (embedded via OpenAI). A duplicate URL is rejected

--- a/scripts/review-pr.sh
+++ b/scripts/review-pr.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Review an existing PR via the Backflow API
+# Review an existing PR via the Backlite API
 #
 # Usage:
 #   ./scripts/review-pr.sh <pr_url> [options]

--- a/scripts/test-blackbox.sh
+++ b/scripts/test-blackbox.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# Run the Backflow black-box integration test suite.
+# Run the Backlite black-box integration test suite.
 set -euo pipefail
 
 usage() {
     cat <<EOF
 Usage: $(basename "$0") [options]
 
-Run the Backflow black-box integration test suite.
+Run the Backlite black-box integration test suite.
 
-Builds the Backflow binary and fake agent Docker image, starts the SQLite-backed
+Builds the Backlite binary and fake agent Docker image, starts the SQLite-backed
 black-box harness, and exercises the full task lifecycle.
 
 Prerequisites: Docker daemon must be running.

--- a/scripts/test-schema.sh
+++ b/scripts/test-schema.sh
@@ -7,7 +7,7 @@ usage() {
     cat <<EOF
 Usage: $(basename "$0") [options]
 
-Run schemathesis fuzz tests against the Backflow OpenAPI spec.
+Run schemathesis fuzz tests against the Backlite OpenAPI spec.
 
 Creates a temporary SQLite database, builds and runs the server, then fuzzes
 all endpoints using schemathesis.
@@ -31,7 +31,7 @@ esac
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-DB_PATH="$ROOT_DIR/.cache/backflow-schema-test.db"
+DB_PATH="$ROOT_DIR/.cache/backlite-schema-test.db"
 SERVER_PID=""
 
 cleanup() {
@@ -59,12 +59,12 @@ rm -f "$DB_PATH"
 $GOOSE -dir "$ROOT_DIR/migrations" sqlite3 "$DB_PATH" up
 
 echo "Building..."
-(cd "$ROOT_DIR" && go build -trimpath -o bin/backflow ./cmd/backflow)
+(cd "$ROOT_DIR" && go build -trimpath -o bin/backlite ./cmd/backlite)
 
 echo "Starting server..."
 BACKFLOW_DATABASE_PATH="$DB_PATH" \
 ANTHROPIC_API_KEY=sk-ant-fuzz-placeholder-not-real \
-    "$ROOT_DIR/bin/backflow" &
+    "$ROOT_DIR/bin/backlite" &
 SERVER_PID=$!
 
 echo "Waiting for server..."

--- a/scripts/test-soak.sh
+++ b/scripts/test-soak.sh
@@ -5,13 +5,13 @@ usage() {
     cat <<EOF
 Usage: $(basename "$0") [options]
 
-Run the Backflow soak test (long-running resource leak detector).
+Run the Backlite soak test (long-running resource leak detector).
 Exercises cancel, retry, retry limits, and mixed failure modes.
 
 Requires: BACKFLOW_CONTAINERS_PER_INSTANCE >= 4 (multi-step scenarios
-need concurrent container slots). Set BACKFLOW_AGENT_IMAGE=backflow-fake-agent.
+need concurrent container slots). Set BACKFLOW_AGENT_IMAGE=backlite-fake-agent.
 
-Starts a dedicated Backflow subprocess against the soak SQLite database.
+Starts a dedicated Backlite subprocess against the soak SQLite database.
 WARNING: This will DELETE task data from that soak database.
 
 Options:
@@ -29,7 +29,7 @@ EOF
 default_soak_db_path() {
     local base="${1:-}"
     if [ -z "$base" ]; then
-        base="./backflow.db"
+        base="./backlite.db"
     fi
     case "$base" in
         *-soak.db) printf '%s\n' "$base" ;;
@@ -48,7 +48,7 @@ if [ -f .env ]; then
 fi
 
 cat <<'WARNING'
-WARNING: The soak test starts a dedicated Backflow subprocess against the soak SQLite database.
+WARNING: The soak test starts a dedicated Backlite subprocess against the soak SQLite database.
 That database will be truncated before and after the run.
 All existing soak task records will be deleted.
 WARNING

--- a/test/blackbox/auth_test.go
+++ b/test/blackbox/auth_test.go
@@ -18,7 +18,7 @@ import (
 func TestAuth_EnvToken_AllowsAndRejects(t *testing.T) {
 	resetBetweenTests(t)
 
-	baseURL, stop := startAuthBackflow(t, "env-secret", "env-secret")
+	baseURL, stop := startAuthBacklite(t, "env-secret", "env-secret")
 	defer stop()
 
 	if got := statusCode(t, baseURL, "/api/v1/health", ""); got != http.StatusUnauthorized {
@@ -34,7 +34,7 @@ func TestAuth_DatabaseKey_AllowsAndRejects(t *testing.T) {
 
 	seedAPIKey(t, "db-valid", []string{"health:read"}, nil)
 
-	baseURL, stop := startAuthBackflow(t, "", "db-valid")
+	baseURL, stop := startAuthBacklite(t, "", "db-valid")
 	defer stop()
 
 	if got := statusCode(t, baseURL, "/api/v1/health", ""); got != http.StatusUnauthorized {
@@ -52,7 +52,7 @@ func TestAuth_DatabaseKey_RejectsExpired(t *testing.T) {
 	expired := time.Now().Add(-time.Hour)
 	seedAPIKey(t, "db-expired", []string{"health:read"}, &expired)
 
-	baseURL, stop := startAuthBackflow(t, "", "db-valid")
+	baseURL, stop := startAuthBacklite(t, "", "db-valid")
 	defer stop()
 
 	if got := statusCode(t, baseURL, "/api/v1/health", "db-expired"); got != http.StatusUnauthorized {
@@ -93,7 +93,7 @@ func seedAPIKey(t *testing.T, token string, permissions []string, expiresAt *tim
 	}
 }
 
-func startAuthBackflow(t *testing.T, envToken, healthToken string) (string, func()) {
+func startAuthBacklite(t *testing.T, envToken, healthToken string) (string, func()) {
 	t.Helper()
 
 	port, err := freePort()
@@ -113,7 +113,7 @@ func startAuthBackflow(t *testing.T, envToken, healthToken string) (string, func
 	}
 
 	if err := cmd.Start(); err != nil {
-		t.Fatalf("start backflow subprocess: %v", err)
+		t.Fatalf("start backlite subprocess: %v", err)
 	}
 
 	if err := waitForHealthWithToken(baseURL, healthToken, 30*time.Second); err != nil {

--- a/test/blackbox/client_test.go
+++ b/test/blackbox/client_test.go
@@ -12,22 +12,22 @@ import (
 	"time"
 )
 
-// BackflowClient wraps net/http calls to the Backflow REST API. All methods
+// BackliteClient wraps net/http calls to the Backlite REST API. All methods
 // accept a *testing.T and fatal on unexpected errors, keeping test code concise.
-type BackflowClient struct {
+type BackliteClient struct {
 	baseURL string
 	http    *http.Client
 }
 
-func newBackflowClient(baseURL string) *BackflowClient {
-	return &BackflowClient{
+func newBackliteClient(baseURL string) *BackliteClient {
+	return &BackliteClient{
 		baseURL: baseURL,
 		http:    &http.Client{Timeout: 10 * time.Second},
 	}
 }
 
 // CreateTask POSTs a new task and returns the unwrapped data object.
-func (c *BackflowClient) CreateTask(t *testing.T, req map[string]any) map[string]any {
+func (c *BackliteClient) CreateTask(t *testing.T, req map[string]any) map[string]any {
 	t.Helper()
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -51,7 +51,7 @@ func (c *BackflowClient) CreateTask(t *testing.T, req map[string]any) map[string
 // CreateTaskRaw POSTs a new task and returns the raw status code and response
 // body. Unlike CreateTask, it does not fatal on non-201 responses, making it
 // suitable for testing validation errors.
-func (c *BackflowClient) CreateTaskRaw(t *testing.T, req map[string]any) (int, map[string]any) {
+func (c *BackliteClient) CreateTaskRaw(t *testing.T, req map[string]any) (int, map[string]any) {
 	t.Helper()
 	body, err := json.Marshal(req)
 	if err != nil {
@@ -83,7 +83,7 @@ func (c *BackflowClient) CreateTaskRaw(t *testing.T, req map[string]any) (int, m
 }
 
 // GetTask retrieves a task by ID.
-func (c *BackflowClient) GetTask(t *testing.T, id string) map[string]any {
+func (c *BackliteClient) GetTask(t *testing.T, id string) map[string]any {
 	t.Helper()
 	resp, err := c.http.Get(c.baseURL + "/api/v1/tasks/" + id)
 	if err != nil {
@@ -100,7 +100,7 @@ func (c *BackflowClient) GetTask(t *testing.T, id string) map[string]any {
 }
 
 // ListTasks lists tasks with optional query parameters.
-func (c *BackflowClient) ListTasks(t *testing.T, params url.Values) []map[string]any {
+func (c *BackliteClient) ListTasks(t *testing.T, params url.Values) []map[string]any {
 	t.Helper()
 	u := c.baseURL + "/api/v1/tasks"
 	if len(params) > 0 {
@@ -122,7 +122,7 @@ func (c *BackflowClient) ListTasks(t *testing.T, params url.Values) []map[string
 }
 
 // DeleteTask cancels/deletes a task by ID.
-func (c *BackflowClient) DeleteTask(t *testing.T, id string) {
+func (c *BackliteClient) DeleteTask(t *testing.T, id string) {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodDelete, c.baseURL+"/api/v1/tasks/"+id, nil)
 	if err != nil {
@@ -142,7 +142,7 @@ func (c *BackflowClient) DeleteTask(t *testing.T, id string) {
 }
 
 // RetryTask retries a task by ID via POST /api/v1/tasks/{id}/retry.
-func (c *BackflowClient) RetryTask(t *testing.T, id string) map[string]any {
+func (c *BackliteClient) RetryTask(t *testing.T, id string) map[string]any {
 	t.Helper()
 	resp, err := c.http.Post(c.baseURL+"/api/v1/tasks/"+id+"/retry", "application/json", nil)
 	if err != nil {
@@ -159,7 +159,7 @@ func (c *BackflowClient) RetryTask(t *testing.T, id string) map[string]any {
 }
 
 // WaitForReadyForRetry polls GetTask until ready_for_retry is true.
-func (c *BackflowClient) WaitForReadyForRetry(t *testing.T, id string, timeout time.Duration) {
+func (c *BackliteClient) WaitForReadyForRetry(t *testing.T, id string, timeout time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
@@ -173,7 +173,7 @@ func (c *BackflowClient) WaitForReadyForRetry(t *testing.T, id string, timeout t
 }
 
 // GetLogs retrieves the logs for a task as plain text.
-func (c *BackflowClient) GetLogs(t *testing.T, id string) string {
+func (c *BackliteClient) GetLogs(t *testing.T, id string) string {
 	t.Helper()
 	resp, err := c.http.Get(c.baseURL + "/api/v1/tasks/" + id + "/logs")
 	if err != nil {
@@ -195,7 +195,7 @@ const stuckStateTimeout = 15 * time.Second
 
 // WaitForStatus polls GetTask until the task reaches the desired status or the
 // timeout expires. Returns the final task state.
-func (c *BackflowClient) WaitForStatus(t *testing.T, id, status string, timeout time.Duration) map[string]any {
+func (c *BackliteClient) WaitForStatus(t *testing.T, id, status string, timeout time.Duration) map[string]any {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	var lastStatus string
@@ -225,7 +225,7 @@ func (c *BackflowClient) WaitForStatus(t *testing.T, id, status string, timeout 
 }
 
 // HealthCheck asserts the health endpoint returns 200.
-func (c *BackflowClient) HealthCheck(t *testing.T) {
+func (c *BackliteClient) HealthCheck(t *testing.T) {
 	t.Helper()
 	resp, err := c.http.Get(c.baseURL + "/api/v1/health")
 	if err != nil {
@@ -240,7 +240,7 @@ func (c *BackflowClient) HealthCheck(t *testing.T) {
 
 // unwrapData reads a JSON response with {"data": ...} envelope and returns the
 // data as map[string]any.
-func (c *BackflowClient) unwrapData(t *testing.T, resp *http.Response) map[string]any {
+func (c *BackliteClient) unwrapData(t *testing.T, resp *http.Response) map[string]any {
 	t.Helper()
 	var envelope struct {
 		Data  json.RawMessage `json:"data"`
@@ -261,7 +261,7 @@ func (c *BackflowClient) unwrapData(t *testing.T, resp *http.Response) map[strin
 }
 
 // unwrapDataList reads a JSON response with {"data": [...]} envelope.
-func (c *BackflowClient) unwrapDataList(t *testing.T, resp *http.Response) []map[string]any {
+func (c *BackliteClient) unwrapDataList(t *testing.T, resp *http.Response) []map[string]any {
 	t.Helper()
 	var envelope struct {
 		Data  json.RawMessage `json:"data"`

--- a/test/blackbox/fake-agent/fake_agent_test.go
+++ b/test/blackbox/fake-agent/fake_agent_test.go
@@ -16,10 +16,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/backflow-labs/backflow/internal/orchestrator"
+	"github.com/brian-bell/backlite/internal/orchestrator"
 )
 
-const imageName = "backflow-fake-agent"
+const imageName = "backlite-fake-agent"
 
 func TestMain(m *testing.M) {
 	_, thisFile, _, ok := runtime.Caller(0)
@@ -101,9 +101,9 @@ func removeContainer(t *testing.T, containerID string) {
 	_ = exec.Command("docker", "rm", "-f", containerID).Run()
 }
 
-// parseBackflowStatusLine finds the BACKFLOW_STATUS_JSON: line in logs and
+// parseBackliteStatusLine finds the BACKFLOW_STATUS_JSON: line in logs and
 // returns the parsed JSON payload. Returns nil if no such line exists.
-func parseBackflowStatusLine(t *testing.T, logs string) []byte {
+func parseBackliteStatusLine(t *testing.T, logs string) []byte {
 	t.Helper()
 	for line := range strings.SplitSeq(logs, "\n") {
 		line = strings.TrimSpace(line)
@@ -214,7 +214,7 @@ func TestFakeAgent(t *testing.T) {
 				}
 
 				// Check BACKFLOW_STATUS_JSON line matches the file
-				logPayload := parseBackflowStatusLine(t, logs)
+				logPayload := parseBackliteStatusLine(t, logs)
 				if logPayload == nil {
 					t.Fatal("expected BACKFLOW_STATUS_JSON: line in stdout, but not found")
 				}
@@ -229,7 +229,7 @@ func TestFakeAgent(t *testing.T) {
 				if statusData != nil {
 					t.Errorf("expected no status.json for outcome %q, but found one: %s", tt.outcome, statusData)
 				}
-				logPayload := parseBackflowStatusLine(t, logs)
+				logPayload := parseBackliteStatusLine(t, logs)
 				if logPayload != nil {
 					t.Errorf("expected no BACKFLOW_STATUS_JSON line for outcome %q, but found: %s", tt.outcome, logPayload)
 				}
@@ -265,7 +265,7 @@ func TestFakeAgentTimeout(t *testing.T) {
 
 	// No BACKFLOW_STATUS_JSON line
 	logs := containerLogs(t, containerID)
-	logPayload := parseBackflowStatusLine(t, logs)
+	logPayload := parseBackliteStatusLine(t, logs)
 	if logPayload != nil {
 		t.Errorf("expected no BACKFLOW_STATUS_JSON line for timeout, but found: %s", logPayload)
 	}

--- a/test/blackbox/harness_test.go
+++ b/test/blackbox/harness_test.go
@@ -20,14 +20,14 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 // Shared state initialized by TestMain and used by all tests.
 var (
 	backflowURL        string
 	backflowBinaryPath string
-	client             *BackflowClient
+	client             *BackliteClient
 	listener           *WebhookListener
 	dbPool             *sql.DB
 	dbPath             string
@@ -66,11 +66,11 @@ func TestMain(m *testing.M) {
 
 	ctx := context.Background()
 
-	// --- Step 1: Build the Backflow binary ---
-	binaryPath := filepath.Join(repoRoot, "bin", "backflow-test")
+	// --- Step 1: Build the Backlite binary ---
+	binaryPath := filepath.Join(repoRoot, "bin", "backlite-test")
 	backflowBinaryPath = binaryPath
-	fmt.Println("==> Building Backflow binary...")
-	build := exec.Command("go", "build", "-trimpath", "-o", binaryPath, "./cmd/backflow")
+	fmt.Println("==> Building Backlite binary...")
+	build := exec.Command("go", "build", "-trimpath", "-o", binaryPath, "./cmd/backlite")
 	build.Dir = repoRoot
 	build.Stdout = os.Stdout
 	build.Stderr = os.Stderr
@@ -82,7 +82,7 @@ func TestMain(m *testing.M) {
 	// --- Step 2: Build the fake agent Docker image ---
 	fakeAgentDir := filepath.Join(repoRoot, "test", "blackbox", "fake-agent")
 	fmt.Println("==> Building fake agent Docker image...")
-	dockerBuild := exec.Command("docker", "build", "-t", "backflow-fake-agent:test", fakeAgentDir)
+	dockerBuild := exec.Command("docker", "build", "-t", "backlite-fake-agent:test", fakeAgentDir)
 	dockerBuild.Stdout = os.Stdout
 	dockerBuild.Stderr = os.Stderr
 	if err := dockerBuild.Run(); err != nil {
@@ -91,7 +91,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// --- Step 3: Create and migrate the SQLite test DB ---
-	dbPath = filepath.Join(repoRoot, "test", "blackbox", "backflow-blackbox-test.db")
+	dbPath = filepath.Join(repoRoot, "test", "blackbox", "backlite-blackbox-test.db")
 	_ = os.Remove(dbPath)
 	bootstrapStore, err := store.NewSQLite(ctx, dbPath, filepath.Join(repoRoot, "migrations"))
 	if err != nil {
@@ -117,7 +117,7 @@ func TestMain(m *testing.M) {
 	fmt.Println("==> Starting webhook listener...")
 	listener = newWebhookListener()
 
-	// --- Step 5: Find a free port for Backflow ---
+	// --- Step 5: Find a free port for Backlite ---
 	port, err := freePort()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "find free port: %v\n", err)
@@ -125,8 +125,8 @@ func TestMain(m *testing.M) {
 	}
 	backflowURL = fmt.Sprintf("http://localhost:%d", port)
 
-	// --- Step 6: Start the Backflow subprocess ---
-	fmt.Printf("==> Starting Backflow subprocess on :%d...\n", port)
+	// --- Step 6: Start the Backlite subprocess ---
+	fmt.Printf("==> Starting Backlite subprocess on :%d...\n", port)
 	stderrBuf = &syncBuffer{}
 
 	backflowCmd = exec.Command(binaryPath)
@@ -136,24 +136,24 @@ func TestMain(m *testing.M) {
 	backflowCmd.Env = buildSubprocessEnv(port, dbPath, listener.URL())
 
 	if err := backflowCmd.Start(); err != nil {
-		fmt.Fprintf(os.Stderr, "start backflow subprocess: %v\n", err)
+		fmt.Fprintf(os.Stderr, "start backlite subprocess: %v\n", err)
 		os.Exit(1)
 	}
 
 	// --- Step 7: Create client and wait for health ---
-	client = newBackflowClient(backflowURL)
+	client = newBackliteClient(backflowURL)
 
-	fmt.Println("==> Waiting for Backflow health check...")
+	fmt.Println("==> Waiting for Backlite health check...")
 	if err := waitForHealth(backflowURL, 30*time.Second); err != nil {
 		fmt.Fprintf(os.Stderr, "health check failed: %v\n", err)
-		fmt.Fprintln(os.Stderr, "--- Backflow stderr ---")
+		fmt.Fprintln(os.Stderr, "--- Backlite stderr ---")
 		fmt.Fprintln(os.Stderr, stderrBuf.String())
 		fmt.Fprintln(os.Stderr, "--- end ---")
 		backflowCmd.Process.Kill()
 		os.Exit(1)
 	}
 
-	fmt.Println("==> Backflow is ready, running tests...")
+	fmt.Println("==> Backlite is ready, running tests...")
 
 	// --- Run tests ---
 	code := m.Run()
@@ -181,12 +181,12 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-// buildSubprocessEnv constructs a clean environment for the Backflow subprocess,
+// buildSubprocessEnv constructs a clean environment for the Backlite subprocess,
 // avoiding interference from inherited env vars (e.g., BACKFLOW_DISCORD_APP_ID).
 func buildSubprocessEnv(port int, dbPath, webhookURL string) []string {
 	env := []string{
 		"BACKFLOW_POLL_INTERVAL_SEC=1",
-		"BACKFLOW_AGENT_IMAGE=backflow-fake-agent:test",
+		"BACKFLOW_AGENT_IMAGE=backlite-fake-agent:test",
 		fmt.Sprintf("BACKFLOW_LISTEN_ADDR=:%d", port),
 		fmt.Sprintf("BACKFLOW_DATABASE_PATH=%s", dbPath),
 		fmt.Sprintf("BACKFLOW_WEBHOOK_URL=%s", webhookURL),
@@ -343,12 +343,12 @@ func orchestratorState(ctx context.Context) (int, int, error) {
 	return activeTasks, runningContainers, nil
 }
 
-// dumpLogsOnFailure returns a cleanup function that dumps the Backflow
+// dumpLogsOnFailure returns a cleanup function that dumps the Backlite
 // subprocess stderr if the test failed. Register via t.Cleanup.
 func dumpLogsOnFailure(t *testing.T) func() {
 	return func() {
 		if t.Failed() {
-			t.Logf("--- Backflow subprocess stderr ---\n%s\n--- end ---", stderrBuf.String())
+			t.Logf("--- Backlite subprocess stderr ---\n%s\n--- end ---", stderrBuf.String())
 		}
 	}
 }

--- a/test/soak/main.go
+++ b/test/soak/main.go
@@ -28,7 +28,7 @@ func main() {
 		duration     = flag.Duration("duration", 1*time.Hour, "total test duration")
 		short        = flag.Bool("short", false, "run a short soak test (10 minutes)")
 		taskInterval = flag.Duration("task-interval", 3*time.Second, "interval between task submissions")
-		agentImage   = flag.String("agent-image", "backflow-fake-agent:test", "agent image name for container counting")
+		agentImage   = flag.String("agent-image", "backlite-fake-agent:test", "agent image name for container counting")
 		databasePath = flag.String("database-path", defaultDatabasePath, "SQLite database path for the dedicated soak server (default: $BACKFLOW_DATABASE_PATH with -soak.db suffix)")
 		maxRetries   = flag.Int("max-retries", 2, "max user retries (must match server BACKFLOW_MAX_USER_RETRIES)")
 	)
@@ -237,7 +237,7 @@ func main() {
 
 func defaultSoakDatabasePath(base string) string {
 	if base == "" {
-		base = "./backflow.db"
+		base = "./backlite.db"
 	}
 	if strings.HasSuffix(base, "-soak.db") {
 		return base
@@ -254,13 +254,13 @@ func startSoakServer(databasePath, agentImage string) (string, func(), error) {
 		return "", nil, err
 	}
 
-	tempDir, err := os.MkdirTemp("", "backflow-soak-*")
+	tempDir, err := os.MkdirTemp("", "backlite-soak-*")
 	if err != nil {
 		return "", nil, fmt.Errorf("create temp dir: %w", err)
 	}
 
-	binaryPath := filepath.Join(tempDir, "backflow-soak")
-	build := exec.Command("go", "build", "-trimpath", "-o", binaryPath, "./cmd/backflow")
+	binaryPath := filepath.Join(tempDir, "backlite-soak")
+	build := exec.Command("go", "build", "-trimpath", "-o", binaryPath, "./cmd/backlite")
 	build.Dir = repoRoot
 	build.Stdout = os.Stdout
 	build.Stderr = os.Stderr
@@ -275,7 +275,7 @@ func startSoakServer(databasePath, agentImage string) (string, func(), error) {
 		return "", nil, fmt.Errorf("find free port: %w", err)
 	}
 
-	logPath := filepath.Join(tempDir, "backflow-soak.log")
+	logPath := filepath.Join(tempDir, "backlite-soak.log")
 	logFile, err := os.Create(logPath)
 	if err != nil {
 		_ = os.RemoveAll(tempDir)
@@ -428,7 +428,7 @@ type debugStatsResponse struct {
 	} `json:"data"`
 }
 
-// collectMetrics gathers one metric sample from the running Backflow instance.
+// collectMetrics gathers one metric sample from the running Backlite instance.
 func collectMetrics(client *http.Client, apiURL, agentImage string, knownPID int) (MetricSample, int, error) {
 	var sample MetricSample
 

--- a/test/soak/main_test.go
+++ b/test/soak/main_test.go
@@ -9,7 +9,7 @@ import (
 
 	_ "modernc.org/sqlite"
 
-	"github.com/backflow-labs/backflow/internal/store"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 func TestTruncateTasks_ClearsCurrentSchema(t *testing.T) {
@@ -68,10 +68,10 @@ func TestDefaultSoakDatabasePath(t *testing.T) {
 		base string
 		want string
 	}{
-		{name: "empty", base: "", want: "./backflow-soak.db"},
-		{name: "sqlite file", base: "./backflow.db", want: "./backflow-soak.db"},
-		{name: "already soak file", base: "./backflow-soak.db", want: "./backflow-soak.db"},
-		{name: "non db path", base: "./tmp/backflow", want: "./tmp/backflow-soak.db"},
+		{name: "empty", base: "", want: "./backlite-soak.db"},
+		{name: "sqlite file", base: "./backlite.db", want: "./backlite-soak.db"},
+		{name: "already soak file", base: "./backlite-soak.db", want: "./backlite-soak.db"},
+		{name: "non db path", base: "./tmp/backlite", want: "./tmp/backlite-soak.db"},
 	}
 
 	for _, tt := range tests {
@@ -92,16 +92,16 @@ func TestBuildSoakServerEnv(t *testing.T) {
 	t.Setenv("HOME", "/tmp/home")
 	t.Setenv("ANTHROPIC_API_KEY", "")
 
-	env := envSliceToMap(buildSoakServerEnv(18080, "/tmp/backflow-soak.db", "backflow-fake-agent:test"))
+	env := envSliceToMap(buildSoakServerEnv(18080, "/tmp/backlite-soak.db", "backlite-fake-agent:test"))
 
-	if env["BACKFLOW_DATABASE_PATH"] != "/tmp/backflow-soak.db" {
-		t.Fatalf("BACKFLOW_DATABASE_PATH = %q, want /tmp/backflow-soak.db", env["BACKFLOW_DATABASE_PATH"])
+	if env["BACKFLOW_DATABASE_PATH"] != "/tmp/backlite-soak.db" {
+		t.Fatalf("BACKFLOW_DATABASE_PATH = %q, want /tmp/backlite-soak.db", env["BACKFLOW_DATABASE_PATH"])
 	}
 	if env["BACKFLOW_LISTEN_ADDR"] != ":18080" {
 		t.Fatalf("BACKFLOW_LISTEN_ADDR = %q, want :18080", env["BACKFLOW_LISTEN_ADDR"])
 	}
-	if env["BACKFLOW_AGENT_IMAGE"] != "backflow-fake-agent:test" {
-		t.Fatalf("BACKFLOW_AGENT_IMAGE = %q, want backflow-fake-agent:test", env["BACKFLOW_AGENT_IMAGE"])
+	if env["BACKFLOW_AGENT_IMAGE"] != "backlite-fake-agent:test" {
+		t.Fatalf("BACKFLOW_AGENT_IMAGE = %q, want backlite-fake-agent:test", env["BACKFLOW_AGENT_IMAGE"])
 	}
 	if env["BACKFLOW_API_KEY"] != "" {
 		t.Fatalf("BACKFLOW_API_KEY = %q, want empty", env["BACKFLOW_API_KEY"])


### PR DESCRIPTION
## Summary
- rename the Go module, `cmd/backlite` entrypoint, built binary, server Dockerfile, CI paths, and default local image tags from backflow to backlite on top of the SQLite runtime
- update helper scripts, reader scripts, agent PR instructions, tests, and API spec text to use the backlite runtime name while keeping the `BACKFLOW_*` env prefix for compatibility
- add `docs/self-hosting.md` for the local Docker + SQLite setup flow, including `BACKFLOW_DATABASE_PATH`, `BACKFLOW_DATA_DIR`, and reader-mode API lookup guidance

## Why
Issue #7 tracks the repo rename and docs cleanup needed after the fork. This PR aligns the runtime artifacts with the `backlite` name and removes stale deployment guidance from the primary documentation surface.

## Validation
- `GOCACHE=/tmp/backlite-pr25/.gocache go build -trimpath -o bin/backlite ./cmd/backlite`
- `go vet ./...`
- `go test -tags nocontainers ./... -v -count=1`
- `git diff --check origin/main...HEAD`
