### PR TITLE
Fix main CI regressions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           cache: true
 
       - name: Install goose
-        run: go install github.com/pressly/goose/v3/cmd/goose@latest
+        run: go install github.com/pressly/goose/v3/cmd/goose@v3.27.0
 
       - name: Run migrations
         run: |

--- a/internal/orchestrator/monitor_test.go
+++ b/internal/orchestrator/monitor_test.go
@@ -1104,19 +1104,12 @@ func TestMonitorRunning_SaveMetadataRunsAfterCompleteTask(t *testing.T) {
 	s := newMockStore()
 	now := time.Now().UTC()
 
-	s.CreateInstance(context.Background(), &models.Instance{
-		InstanceID:        "local",
-		Status:            models.InstanceStatusRunning,
-		MaxContainers:     4,
-		RunningContainers: 1,
-	})
 	s.CreateTask(context.Background(), &models.Task{
 		ID:              "bf_order",
 		Status:          models.TaskStatusRunning,
 		RepoURL:         "https://github.com/test/repo",
 		Prompt:          "finish me",
 		SaveAgentOutput: true,
-		InstanceID:      "local",
 		ContainerID:     "cont1",
 		StartedAt:       &now,
 		CreatedAt:       now,
@@ -1126,7 +1119,7 @@ func TestMonitorRunning_SaveMetadataRunsAfterCompleteTask(t *testing.T) {
 	root := t.TempDir()
 	mock := &mockDockerManager{
 		inspectResults: map[string]ContainerStatus{
-			"local/cont1": {
+			"cont1": {
 				Done:         true,
 				Complete:     true,
 				ExitCode:     0,


### PR DESCRIPTION
## Summary
- Pin the CI goose install to v3.27.0 instead of @latest so the push-only fuzz job stays compatible with the Go 1.25.0 toolchain from go.mod.
- Update the output metadata regression test from #38 to use the post-instance-table container fixture after #35 removed models.Instance, Task.InstanceID, and instance-scoped container keys.

## Verification
- go vet ./...
- go test ./internal/orchestrator -run TestMonitorRunning_SaveMetadataRunsAfterCompleteTask -count=1
- go test $(go list ./... | grep -v '/test/blackbox') -race -count=1
- go test ./test/blackbox/ -v -count=1 -timeout 120s
- /tmp/backlite-go-bin/goose -version -> v3.27.0