### PR TITLE
Trim unused Makefile targets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,19 +17,12 @@ make test-schema        # Schemathesis fuzz tests against OpenAPI spec (requires
 make test-blackbox      # Black-box integration test (builds fake agent, spins up server + DB)
 make test-soak          # Soak test (10 min short mode; starts dedicated server on sibling -soak.db)
 make test-fake-agent    # Unit tests for the fake agent Docker image
-make test-reader-scripts         # Reader-agent shell script tests
-make test-reader-status-writer   # Reader-agent status writer test
-make test-docker-status-writer   # Agent-container status writer test
-make docker-fake-agent-build  # Build fake agent image for testing
 make deps               # go mod tidy
 make clean              # Remove bin/ directory
-make db-running         # Show running tasks (also: db-pending, db-completed, db-failed, etc.)
-make docker-agent-build       # Buildx multi-platform agent image (amd64+arm64)
-make docker-agent-build-local # Single-architecture agent build
-make docker-server-build       # Buildx multi-platform server image (amd64+arm64)
-make docker-server-build-local # Single-architecture server build
-make docker-reader-build       # Buildx multi-platform reader image (amd64+arm64)
-make docker-reader-build-local # Single-architecture reader build
+make db-running         # Show running tasks (also: db-pending, db-completed, db-failed)
+make docker-agent-build-local  # Agent image (native arch)
+make docker-server-build-local # Server image (native arch)
+make docker-reader-build-local # Reader image (native arch)
 goose -dir migrations status # Show pending/applied migrations
 goose -dir migrations up     # Apply the next migration(s)
 goose -dir migrations down   # Roll back the last migration

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,12 @@
 .PHONY: build run test clean lint \
-       docker-agent-build docker-agent-build-local \
-       docker-reader-build docker-reader-build-local \
-       docker-server-build docker-server-build-local \
-       docker-fake-agent-build test-fake-agent test-blackbox test-schema test-soak \
-       db-pending db-provisioning db-running db-completed db-failed db-interrupted db-cancelled db-recovering \
-       deps test-docker-status-writer test-reader-status-writer \
-       test-reader-scripts
+       docker-agent-build-local \
+       docker-reader-build-local \
+       docker-server-build-local \
+       test-fake-agent test-blackbox test-schema test-soak \
+       db-pending db-running db-completed db-failed \
+       deps
 
 BINARY := backlite
-PKG := github.com/brian-bell/backlite
 GOFLAGS := -trimpath
 export PATH := $(HOME)/.local/go/bin:$(HOME)/go/bin:$(PATH)
 
@@ -28,20 +26,8 @@ run: build
 test:
 	go test -tags nocontainers ./... -v -count=1
 
-test-docker-status-writer:
-	bash scripts/test-docker-status-writer.sh
-
-test-reader-status-writer:
-	bash scripts/test-reader-status-writer.sh
-
-test-reader-scripts:
-	bash docker/reader/test_read_scripts.sh
-	bash docker/reader/test_entrypoint.sh
-
-docker-fake-agent-build:
+test-fake-agent:
 	$(DOCKER) build -t backlite-fake-agent test/blackbox/fake-agent/
-
-test-fake-agent: docker-fake-agent-build
 	go test ./test/blackbox/fake-agent/ -v -count=1
 
 test-blackbox:
@@ -59,29 +45,11 @@ lint:
 clean:
 	rm -rf bin/
 
-docker-agent-build:
-	$(DOCKER) buildx build \
-		--platform linux/amd64,linux/arm64 \
-		-t backlite-agent \
-		docker/agent/
-
 docker-agent-build-local:
 	$(DOCKER) build -t backlite-agent docker/agent/
 
-docker-reader-build:
-	$(DOCKER) buildx build \
-		--platform linux/amd64,linux/arm64 \
-		-t backlite-reader \
-		docker/reader/
-
 docker-reader-build-local:
 	$(DOCKER) build -t backlite-reader docker/reader/
-
-docker-server-build:
-	$(DOCKER) buildx build \
-		--platform linux/amd64,linux/arm64 \
-		-t backlite-server \
-		-f docker/server/Dockerfile .
 
 docker-server-build-local:
 	$(DOCKER) build -t backlite-server -f docker/server/Dockerfile .
@@ -91,9 +59,6 @@ DB_QUERY = @$(ENV); sqlite3 -json "$$BACKFLOW_DATABASE_PATH"
 db-pending:
 	$(DB_QUERY) "SELECT id, repo_url, branch, harness, created_at FROM tasks WHERE status = 'pending' ORDER BY created_at ASC;"
 
-db-provisioning:
-	$(DB_QUERY) "SELECT id, repo_url, branch, harness, created_at FROM tasks WHERE status = 'provisioning' ORDER BY created_at ASC;"
-
 db-running:
 	$(DB_QUERY) "SELECT id, repo_url, branch, harness, model, started_at, elapsed_time_sec FROM tasks WHERE status = 'running' ORDER BY started_at ASC;"
 
@@ -102,15 +67,6 @@ db-completed:
 
 db-failed:
 	$(DB_QUERY) "SELECT id, repo_url, branch, harness, error, completed_at FROM tasks WHERE status = 'failed' ORDER BY completed_at DESC;"
-
-db-interrupted:
-	$(DB_QUERY) "SELECT id, repo_url, branch, harness, error, retry_count, updated_at FROM tasks WHERE status = 'interrupted' ORDER BY updated_at DESC;"
-
-db-cancelled:
-	$(DB_QUERY) "SELECT id, repo_url, branch, harness, completed_at FROM tasks WHERE status = 'cancelled' ORDER BY completed_at DESC;"
-
-db-recovering:
-	$(DB_QUERY) "SELECT id, repo_url, branch, harness, container_id, updated_at FROM tasks WHERE status = 'recovering' ORDER BY updated_at ASC;"
 
 deps:
 	go mod tidy

--- a/README.md
+++ b/README.md
@@ -196,14 +196,9 @@ To add a migration: create a new file in `migrations/` (e.g. `002_add_column.sql
 ## Docker Images
 
 ```bash
-make docker-agent-build-local    # Single-arch agent image
-make docker-agent-build          # Multi-arch buildx (amd64+arm64)
-
-make docker-reader-build-local   # Single-arch reader image (for task_mode=read)
-make docker-reader-build         # Multi-arch buildx
-
-make docker-server-build-local   # Single-arch server image
-make docker-server-build         # Multi-arch buildx
+make docker-agent-build-local    # Agent image
+make docker-reader-build-local   # Reader image (for task_mode=read)
+make docker-server-build-local   # Server image
 ```
 
 Backlite runs agent containers directly against the local Docker daemon; there is no remote orchestration runtime.


### PR DESCRIPTION
## Summary

Cleans out Makefile targets that aren't pulling their weight:

- **Multi-platform `buildx` Docker builds** — `docker-agent-build`, `docker-reader-build`, `docker-server-build`. Backlite is run against a local Docker daemon, so the single-arch `-local` variants cover the actual workflow. Removes the dependency on `docker buildx`.
- **`db-provisioning`, `db-interrupted`, `db-cancelled`, `db-recovering`** — only the four canonical statuses (`pending`/`running`/`completed`/`failed`) were advertised in README.md; the others covered transient/edge states rarely worth a one-shot query.
- **`test-docker-status-writer`, `test-reader-status-writer`, `test-reader-scripts`** — one-line wrappers around shell scripts that weren't documented in README. Call the scripts directly when needed.
- **`docker-fake-agent-build`** — only existed as a prereq for `test-fake-agent`; folded inline.
- **Unused `PKG` variable** — never expanded anywhere.

README.md and CLAUDE.md updated to match.

## Test plan

- [x] `make -n` against every surviving target produces the expected commands
- [x] No CI workflow references the removed targets (CI calls `go` and shell scripts directly, not `make`)
- [ ] `make build`, `make test`, `make lint` still work locally