### PR TITLE
Slice 3 (#46): Image router + BACKFLOW_SKILL_AGENT_IMAGE config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,10 @@ Reading-mode env vars:
 - `OPENAI_API_KEY` — Required for the orchestrator's embeddings client (and for the reader container's `read-embed.sh`)
 - `BACKFLOW_INTERNAL_API_BASE_URL` — Optional override for the Backlite API base URL used by reader containers; defaults to `http://host.docker.internal:<listen-port>`
 
+## Skill-based agent image (opt-in)
+
+- `BACKFLOW_SKILL_AGENT_IMAGE` — Optional. When set and `task.harness == "claude_code"`, the orchestrator routes the task to this image regardless of mode. The image is expected to ship per-mode skill bundles (`code`, `review`, `read`) under `/opt/backflow/skills/`. Codex tasks are unaffected and continue to use the existing agent / reader images. Image-routing logic lives in `internal/orchestrator/imagerouter`.
+
 The `tasks` table carries a `force` boolean column. REST callers can set `force` on `POST /api/v1/tasks`; `Force=true` bypasses the dispatch-time duplicate check and allows an existing reading row to be overwritten on completion.
 
 ## Output storage

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -420,7 +420,7 @@ func TestDeleteTask_EmitsCancelledEvent(t *testing.T) {
 	taskID := resp.Data.ID
 
 	// Transition task to running so cancel path is triggered
-	s.StartTask(ctx, taskID, "container-abc")
+	s.StartTask(ctx, taskID, "container-abc", "")
 
 	// Clear events from creation
 	emitter.events = nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	// Agent
 	AgentImage            string
 	ReaderImage           string
+	SkillAgentImage       string
 	DefaultHarness        string
 	DefaultClaudeModel    string
 	DefaultCodexModel     string
@@ -87,6 +88,7 @@ func Load() (*Config, error) {
 		ContainerMemGB:        envInt("BACKFLOW_CONTAINER_MEMORY_GB", 8),
 		AgentImage:            envOr("BACKFLOW_AGENT_IMAGE", "backlite-agent"),
 		ReaderImage:           os.Getenv("BACKFLOW_READER_IMAGE"),
+		SkillAgentImage:       os.Getenv("BACKFLOW_SKILL_AGENT_IMAGE"),
 		DefaultHarness:        envOr("BACKFLOW_DEFAULT_HARNESS", "claude_code"),
 		DefaultClaudeModel:    envOr("BACKFLOW_DEFAULT_CLAUDE_MODEL", "claude-opus-4-7"),
 		DefaultCodexModel:     envOr("BACKFLOW_DEFAULT_CODEX_MODEL", "gpt-5.4"),

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/orchestrator/imagerouter"
 	"github.com/brian-bell/backlite/internal/store"
 )
 
@@ -63,6 +64,8 @@ func (o *Orchestrator) dispatch(ctx context.Context, task *models.Task) error {
 			}
 		}
 	}
+
+	task.AgentImage = imagerouter.Resolve(task, o.config)
 
 	if err := o.lifecycle.Assign(ctx, task.ID); err != nil {
 		return err

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -51,8 +51,8 @@ func (o *Orchestrator) dispatch(ctx context.Context, task *models.Task) error {
 		if o.embedder == nil {
 			return fmt.Errorf("cannot dispatch read task: no embedder configured (set OPENAI_API_KEY)")
 		}
-		if o.config.ReaderImage == "" {
-			return fmt.Errorf("cannot dispatch read task: no reader image configured (set BACKFLOW_READER_IMAGE)")
+		if !imagerouter.CanRunRead(task, o.config) {
+			return fmt.Errorf("cannot dispatch read task: set BACKFLOW_READER_IMAGE, or BACKFLOW_SKILL_AGENT_IMAGE for claude_code")
 		}
 		if !task.Force {
 			existing, err := o.store.GetReadingByURL(ctx, task.Prompt)

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -308,12 +308,17 @@ func TestDispatch_ReadTaskWithoutEmbedder_Fails(t *testing.T) {
 // orchestrator that doesn't have a reader image configured refuses to dispatch
 // read tasks rather than silently running them on the default agent image.
 // Protects against cross-orchestrator mis-dispatch in shared-DB setups.
+//
+// Uses Harness=Codex to isolate the ReaderImage path: SkillAgentImage is
+// claude_code-only, so a codex read task with no ReaderImage is the only
+// scenario where the guard must still fire even with SkillAgentImage set.
 func TestDispatch_ReadTask_OrchestratorMissingReaderImage_Fails(t *testing.T) {
 	s := newMockStore()
 	task := &models.Task{
 		ID:         "bf_read_no_reader",
 		Status:     models.TaskStatusPending,
 		TaskMode:   models.TaskModeRead,
+		Harness:    models.HarnessCodex,
 		Prompt:     "https://example.com/post",
 		AgentImage: "backlite-reader", // set by the creating orchestrator
 	}
@@ -344,6 +349,50 @@ func TestDispatch_ReadTask_OrchestratorMissingReaderImage_Fails(t *testing.T) {
 	}
 	if got.Status == models.TaskStatusRunning {
 		t.Errorf("task should not be running, got %q", got.Status)
+	}
+}
+
+// TestDispatch_ReadTask_SkillImageWithoutReaderImage_Succeeds pins that an
+// operator who configures BACKFLOW_SKILL_AGENT_IMAGE for a claude_code-only
+// fleet can dispatch read tasks without separately configuring
+// BACKFLOW_READER_IMAGE — the skill bundle ships the read skill, so the
+// router resolves the skill image and dispatch must let it through.
+func TestDispatch_ReadTask_SkillImageWithoutReaderImage_Succeeds(t *testing.T) {
+	s := newMockStore()
+	s.CreateTask(context.Background(), &models.Task{
+		ID:       "bf_read_skill_no_reader",
+		Status:   models.TaskStatusPending,
+		TaskMode: models.TaskModeRead,
+		Harness:  models.HarnessClaudeCode,
+		Prompt:   "https://example.com/post",
+	})
+
+	var captured *models.Task
+	bus, _ := newTestBus()
+	defer bus.Close()
+	mock := &mockDockerManager{
+		runAgentFn: func(_ context.Context, task *models.Task) (string, error) {
+			cp := *task
+			captured = &cp
+			return "container-skill-read", nil
+		},
+		inspectResults: map[string]ContainerStatus{},
+	}
+	o := newTestOrchestrator(s, bus, withDocker(mock), withEmbedder(&mockEmbedder{}))
+	o.config.AgentImage = "backlite-agent"
+	o.config.ReaderImage = ""                            // intentionally unset
+	o.config.SkillAgentImage = "backlite-skill-agent:v1" // covers read via skill bundle
+
+	task, _ := s.GetTask(context.Background(), "bf_read_skill_no_reader")
+	if err := o.dispatch(context.Background(), task); err != nil {
+		t.Fatalf("dispatch: %v (skill image should let read tasks through without ReaderImage)", err)
+	}
+
+	if captured == nil {
+		t.Fatal("RunAgent was not called")
+	}
+	if captured.AgentImage != "backlite-skill-agent:v1" {
+		t.Errorf("captured AgentImage = %q, want %q", captured.AgentImage, "backlite-skill-agent:v1")
 	}
 }
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -155,6 +155,7 @@ func TestDispatch_RoutesCodexToOldImage(t *testing.T) {
 		Harness:    models.HarnessCodex,
 		TaskMode:   models.TaskModeCode,
 		AgentImage: "backlite-agent",
+		RepoURL:    "https://github.com/test/repo",
 		Prompt:     "codex task",
 	})
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -100,6 +100,92 @@ func TestDispatchPending_DispatchesTask(t *testing.T) {
 	}
 }
 
+// TestDispatch_RoutesToSkillAgentImage verifies dispatch consults the
+// imagerouter and overrides task.AgentImage with the resolved value before
+// calling docker.RunAgent. With BACKFLOW_SKILL_AGENT_IMAGE configured and a
+// claude_code task, the skill image should win regardless of the value the
+// task carried in (which would be the default agent image set at creation).
+func TestDispatch_RoutesToSkillAgentImage(t *testing.T) {
+	s := newMockStore()
+	s.CreateTask(context.Background(), &models.Task{
+		ID:         "bf_skill",
+		Status:     models.TaskStatusPending,
+		Harness:    models.HarnessClaudeCode,
+		TaskMode:   models.TaskModeCode,
+		AgentImage: "backlite-agent",
+		RepoURL:    "https://github.com/test/repo",
+		Prompt:     "use the skill image",
+	})
+
+	var captured *models.Task
+	bus, _ := newTestBus()
+	mock := &mockDockerManager{
+		runAgentFn: func(_ context.Context, task *models.Task) (string, error) {
+			cp := *task
+			captured = &cp
+			return "container-skill", nil
+		},
+		inspectResults: map[string]ContainerStatus{},
+	}
+	o := newTestOrchestrator(s, bus, withDocker(mock))
+	o.config.AgentImage = "backlite-agent"
+	o.config.SkillAgentImage = "backlite-skill-agent:v1"
+
+	task, _ := s.GetTask(context.Background(), "bf_skill")
+	if err := o.dispatch(context.Background(), task); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	bus.Close()
+
+	if captured == nil {
+		t.Fatal("RunAgent was not called")
+	}
+	if captured.AgentImage != "backlite-skill-agent:v1" {
+		t.Errorf("captured AgentImage = %q, want %q", captured.AgentImage, "backlite-skill-agent:v1")
+	}
+}
+
+// TestDispatch_RoutesCodexToOldImage pins that codex tasks ignore the skill
+// image even when BACKFLOW_SKILL_AGENT_IMAGE is set.
+func TestDispatch_RoutesCodexToOldImage(t *testing.T) {
+	s := newMockStore()
+	s.CreateTask(context.Background(), &models.Task{
+		ID:         "bf_codex",
+		Status:     models.TaskStatusPending,
+		Harness:    models.HarnessCodex,
+		TaskMode:   models.TaskModeCode,
+		AgentImage: "backlite-agent",
+		Prompt:     "codex task",
+	})
+
+	var captured *models.Task
+	bus, _ := newTestBus()
+	mock := &mockDockerManager{
+		runAgentFn: func(_ context.Context, task *models.Task) (string, error) {
+			cp := *task
+			captured = &cp
+			return "container-codex", nil
+		},
+		inspectResults: map[string]ContainerStatus{},
+	}
+	o := newTestOrchestrator(s, bus, withDocker(mock))
+	o.config.AgentImage = "backlite-agent"
+	o.config.SkillAgentImage = "backlite-skill-agent:v1"
+
+	task, _ := s.GetTask(context.Background(), "bf_codex")
+	if err := o.dispatch(context.Background(), task); err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	bus.Close()
+
+	if captured == nil {
+		t.Fatal("RunAgent was not called")
+	}
+	if captured.AgentImage != "backlite-agent" {
+		t.Errorf("captured AgentImage = %q, want %q (codex ignores skill image)", captured.AgentImage, "backlite-agent")
+	}
+}
+
 func TestDispatchPending_FailedDispatch(t *testing.T) {
 	s := newMockStore()
 	s.CreateTask(context.Background(), &models.Task{

--- a/internal/orchestrator/helpers_test.go
+++ b/internal/orchestrator/helpers_test.go
@@ -113,12 +113,13 @@ func (s *mockStore) AssignTask(_ context.Context, id string) error {
 	return nil
 }
 
-func (s *mockStore) StartTask(_ context.Context, id string, containerID string) error {
+func (s *mockStore) StartTask(_ context.Context, id string, containerID string, agentImage string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if t, ok := s.tasks[id]; ok {
 		t.Status = models.TaskStatusRunning
 		t.ContainerID = containerID
+		t.AgentImage = agentImage
 		now := time.Now().UTC()
 		t.StartedAt = &now
 	}

--- a/internal/orchestrator/imagerouter/imagerouter.go
+++ b/internal/orchestrator/imagerouter/imagerouter.go
@@ -1,0 +1,27 @@
+// Package imagerouter selects the docker image used to run a given task.
+//
+// Routing rules (highest priority first):
+//
+//  1. Skill-agent opt-in: if cfg.SkillAgentImage is set and the task's
+//     harness is claude_code, use the skill-agent image regardless of mode.
+//     Codex tasks are deliberately excluded (the new image is claude_code-only).
+//  2. Read-mode default: if task is read mode and cfg.ReaderImage is set,
+//     use the reader image.
+//  3. Fall back to cfg.AgentImage.
+package imagerouter
+
+import (
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/models"
+)
+
+// Resolve returns the docker image string that should run the given task.
+func Resolve(task *models.Task, cfg *config.Config) string {
+	if cfg.SkillAgentImage != "" && task.Harness == models.HarnessClaudeCode {
+		return cfg.SkillAgentImage
+	}
+	if task.TaskMode == models.TaskModeRead && cfg.ReaderImage != "" {
+		return cfg.ReaderImage
+	}
+	return cfg.AgentImage
+}

--- a/internal/orchestrator/imagerouter/imagerouter.go
+++ b/internal/orchestrator/imagerouter/imagerouter.go
@@ -25,3 +25,18 @@ func Resolve(task *models.Task, cfg *config.Config) string {
 	}
 	return cfg.AgentImage
 }
+
+// CanRunRead reports whether the configured images can host a read-mode task.
+// True when ReaderImage is set, or when SkillAgentImage is set for a
+// claude_code task (the skill bundle ships the read skill). codex tasks
+// require ReaderImage because the skill image is claude_code-only.
+//
+// Dispatch should consult this before starting a read-mode container so
+// operators who run all modes through SkillAgentImage don't need to also
+// configure BACKFLOW_READER_IMAGE.
+func CanRunRead(task *models.Task, cfg *config.Config) bool {
+	if cfg.SkillAgentImage != "" && task.Harness == models.HarnessClaudeCode {
+		return true
+	}
+	return cfg.ReaderImage != ""
+}

--- a/internal/orchestrator/imagerouter/imagerouter_test.go
+++ b/internal/orchestrator/imagerouter/imagerouter_test.go
@@ -1,0 +1,84 @@
+package imagerouter
+
+import (
+	"testing"
+
+	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/models"
+)
+
+func TestResolve_TableDriven(t *testing.T) {
+	const (
+		agentImg  = "backlite-agent:v1"
+		readerImg = "backlite-reader:v1"
+		skillImg  = "backlite-skill-agent:v1"
+	)
+
+	tests := []struct {
+		name      string
+		harness   models.Harness
+		mode      string
+		skillImg  string
+		readerImg string
+		want      string
+	}{
+		// SkillAgentImage unset: behavior matches today's logic.
+		{"claude_code+code, skill unset", models.HarnessClaudeCode, models.TaskModeCode, "", readerImg, agentImg},
+		{"claude_code+review, skill unset", models.HarnessClaudeCode, models.TaskModeReview, "", readerImg, agentImg},
+		{"claude_code+read, skill unset", models.HarnessClaudeCode, models.TaskModeRead, "", readerImg, readerImg},
+		{"claude_code+auto, skill unset", models.HarnessClaudeCode, models.TaskModeAuto, "", readerImg, agentImg},
+		{"codex+code, skill unset", models.HarnessCodex, models.TaskModeCode, "", readerImg, agentImg},
+		{"codex+review, skill unset", models.HarnessCodex, models.TaskModeReview, "", readerImg, agentImg},
+		{"codex+read, skill unset", models.HarnessCodex, models.TaskModeRead, "", readerImg, readerImg},
+
+		// SkillAgentImage set + claude_code: route to skill image regardless of mode.
+		{"claude_code+code, skill set", models.HarnessClaudeCode, models.TaskModeCode, skillImg, readerImg, skillImg},
+		{"claude_code+review, skill set", models.HarnessClaudeCode, models.TaskModeReview, skillImg, readerImg, skillImg},
+		{"claude_code+read, skill set", models.HarnessClaudeCode, models.TaskModeRead, skillImg, readerImg, skillImg},
+		{"claude_code+auto, skill set", models.HarnessClaudeCode, models.TaskModeAuto, skillImg, readerImg, skillImg},
+
+		// SkillAgentImage set + codex: codex tasks still use old images.
+		{"codex+code, skill set", models.HarnessCodex, models.TaskModeCode, skillImg, readerImg, agentImg},
+		{"codex+review, skill set", models.HarnessCodex, models.TaskModeReview, skillImg, readerImg, agentImg},
+		{"codex+read, skill set", models.HarnessCodex, models.TaskModeRead, skillImg, readerImg, readerImg},
+
+		// Reader image unset: read mode falls back to agent image (operator
+		// hasn't enabled read mode at all).
+		{"claude_code+read, reader unset, skill unset", models.HarnessClaudeCode, models.TaskModeRead, "", "", agentImg},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				AgentImage:      agentImg,
+				ReaderImage:     tt.readerImg,
+				SkillAgentImage: tt.skillImg,
+			}
+			task := &models.Task{Harness: tt.harness, TaskMode: tt.mode}
+			got := Resolve(task, cfg)
+			if got != tt.want {
+				t.Errorf("Resolve(%s, %s, skill=%q) = %q, want %q",
+					tt.harness, tt.mode, tt.skillImg, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolve_OverridesPriorAgentImage pins a key behavior: even when the task
+// already carries an AgentImage value (set by creation-time defaults), the
+// router re-derives at dispatch. This is what makes BACKFLOW_SKILL_AGENT_IMAGE
+// a runtime opt-in for in-flight tasks, not just newly created ones.
+func TestResolve_OverridesPriorAgentImage(t *testing.T) {
+	cfg := &config.Config{
+		AgentImage:      "default-agent",
+		SkillAgentImage: "skill-agent",
+	}
+	task := &models.Task{
+		Harness:    models.HarnessClaudeCode,
+		TaskMode:   models.TaskModeCode,
+		AgentImage: "default-agent", // set by creation defaults
+	}
+	if got := Resolve(task, cfg); got != "skill-agent" {
+		t.Errorf("Resolve = %q, want %q (router takes precedence over creation default)", got, "skill-agent")
+	}
+}

--- a/internal/orchestrator/imagerouter/imagerouter_test.go
+++ b/internal/orchestrator/imagerouter/imagerouter_test.go
@@ -64,6 +64,53 @@ func TestResolve_TableDriven(t *testing.T) {
 	}
 }
 
+// TestCanRunRead_TableDriven covers every (harness, skill, reader) combination
+// for read-mode dispatch preconditions. The guard must accept any task whose
+// resolved image will actually have a reader entrypoint — which today means
+// either ReaderImage is set, or SkillAgentImage is set for a claude_code task
+// (the skill bundle ships the read skill). codex tasks must still require
+// ReaderImage since the skill image is claude_code-only.
+func TestCanRunRead_TableDriven(t *testing.T) {
+	const (
+		readerImg = "backlite-reader:v1"
+		skillImg  = "backlite-skill-agent:v1"
+	)
+
+	tests := []struct {
+		name      string
+		harness   models.Harness
+		skillImg  string
+		readerImg string
+		want      bool
+	}{
+		{"claude_code, both unset", models.HarnessClaudeCode, "", "", false},
+		{"claude_code, reader set", models.HarnessClaudeCode, "", readerImg, true},
+		{"claude_code, skill set", models.HarnessClaudeCode, skillImg, "", true},
+		{"claude_code, both set", models.HarnessClaudeCode, skillImg, readerImg, true},
+
+		{"codex, both unset", models.HarnessCodex, "", "", false},
+		{"codex, reader set", models.HarnessCodex, "", readerImg, true},
+		// Skill image is claude_code-only, so codex+read still needs the
+		// dedicated reader image even if SkillAgentImage is set.
+		{"codex, skill set only", models.HarnessCodex, skillImg, "", false},
+		{"codex, both set", models.HarnessCodex, skillImg, readerImg, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				ReaderImage:     tt.readerImg,
+				SkillAgentImage: tt.skillImg,
+			}
+			task := &models.Task{Harness: tt.harness, TaskMode: models.TaskModeRead}
+			if got := CanRunRead(task, cfg); got != tt.want {
+				t.Errorf("CanRunRead(harness=%s, skill=%q, reader=%q) = %v, want %v",
+					tt.harness, tt.skillImg, tt.readerImg, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestResolve_OverridesPriorAgentImage pins a key behavior: even when the task
 // already carries an AgentImage value (set by creation-time defaults), the
 // router re-derives at dispatch. This is what makes BACKFLOW_SKILL_AGENT_IMAGE

--- a/internal/orchestrator/lifecycle/lifecycle.go
+++ b/internal/orchestrator/lifecycle/lifecycle.go
@@ -131,9 +131,11 @@ func (c *Coordinator) Assign(ctx context.Context, taskID string) error {
 
 // Start transitions a task provisioning → running, bumps the local running
 // counter, and emits task.running. The caller is responsible for invoking
-// docker.RunAgent between Assign and Start.
+// docker.RunAgent between Assign and Start. task.AgentImage is persisted at
+// this point so the DB records the image actually used (after any image-router
+// override), not just the creation-time default.
 func (c *Coordinator) Start(ctx context.Context, task *models.Task, containerID string) error {
-	if err := c.store.StartTask(ctx, task.ID, containerID); err != nil {
+	if err := c.store.StartTask(ctx, task.ID, containerID, task.AgentImage); err != nil {
 		return fmt.Errorf("start task: %w", err)
 	}
 	c.slots.Acquire()

--- a/internal/orchestrator/lifecycle/lifecycle_test.go
+++ b/internal/orchestrator/lifecycle/lifecycle_test.go
@@ -180,7 +180,7 @@ func TestMarkRecovering_RunningOrphan_PreservesAssignment(t *testing.T) {
 	ctx := context.Background()
 	task := seedTask(t, s, "bf_MR_RUN", models.TaskStatusRunning)
 	_ = s.AssignTask(ctx, task.ID)
-	_ = s.StartTask(ctx, task.ID, "cont_123")
+	_ = s.StartTask(ctx, task.ID, "cont_123", "")
 	task, _ = s.GetTask(ctx, task.ID)
 
 	emitter := &captureEmitter{}
@@ -258,7 +258,7 @@ func TestRecover_WasRunning_ReleasesSlot(t *testing.T) {
 	ctx := context.Background()
 	task := seedTask(t, s, "bf_REC_WASRUN", models.TaskStatusRecovering)
 	_ = s.AssignTask(ctx, task.ID)
-	_ = s.StartTask(ctx, task.ID, "cont_wasrun")
+	_ = s.StartTask(ctx, task.ID, "cont_wasrun", "")
 	task, _ = s.GetTask(ctx, task.ID)
 
 	emitter := &captureEmitter{}
@@ -281,6 +281,40 @@ func TestRecover_WasRunning_ReleasesSlot(t *testing.T) {
 	}
 }
 
+// TestStart_PersistsAgentImage pins that lifecycle.Start writes the routed
+// agent image to the DB, not just the in-memory pointer. Without persistence,
+// the task.json snapshot written by saveOutputMetadata (after Complete reloads
+// the row) and the task.completed webhook payload both report the
+// creation-time image instead of the image actually used by the container —
+// silently breaking the Task.AgentImage contract whenever the image router
+// overrides it (e.g. BACKFLOW_SKILL_AGENT_IMAGE).
+func TestStart_PersistsAgentImage(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	task := seedTask(t, s, "bf_START_IMG", models.TaskStatusPending)
+	task.AgentImage = "creation-time-image"
+	if err := s.AssignTask(ctx, task.ID); err != nil {
+		t.Fatalf("AssignTask: %v", err)
+	}
+
+	emitter := &captureEmitter{}
+	c := New(s, emitter, WithSlots(&trackingSlots{}))
+
+	// Simulate the orchestrator's image-router override after Assign.
+	task.AgentImage = "routed-skill-image"
+	if err := c.Start(ctx, task, "cont_img"); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	got, err := s.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.AgentImage != "routed-skill-image" {
+		t.Errorf("persisted AgentImage = %q, want %q (Start must write the routed image, not the creation-time value)", got.AgentImage, "routed-skill-image")
+	}
+}
+
 // seedRunningTask creates a task already in the running state with a container
 // set, mirroring what Dispatch leaves behind before Complete fires.
 func seedRunningTask(t *testing.T, s store.Store, id string) *models.Task {
@@ -290,7 +324,7 @@ func seedRunningTask(t *testing.T, s store.Store, id string) *models.Task {
 	if err := s.AssignTask(ctx, task.ID); err != nil {
 		t.Fatalf("AssignTask: %v", err)
 	}
-	if err := s.StartTask(ctx, task.ID, "cont_"+id); err != nil {
+	if err := s.StartTask(ctx, task.ID, "cont_"+id, ""); err != nil {
 		t.Fatalf("StartTask: %v", err)
 	}
 	got, err := s.GetTask(ctx, task.ID)
@@ -419,7 +453,7 @@ func TestComplete_FailurePath_RetryCapReached(t *testing.T) {
 		t.Fatalf("CreateTask: %v", err)
 	}
 	_ = s.AssignTask(ctx, seed.ID)
-	_ = s.StartTask(ctx, seed.ID, "cont_limit")
+	_ = s.StartTask(ctx, seed.ID, "cont_limit", "")
 	task, _ := s.GetTask(ctx, seed.ID)
 
 	emitter := &captureEmitter{}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -198,11 +198,11 @@ func (s *SQLiteStore) AssignTask(ctx context.Context, id string) error {
 	return err
 }
 
-func (s *SQLiteStore) StartTask(ctx context.Context, id string, containerID string) error {
-	now := time.Now().UTC()
+func (s *SQLiteStore) StartTask(ctx context.Context, id string, containerID string, agentImage string) error {
+	now := timeString(time.Now().UTC())
 	_, err := s.q.ExecContext(ctx,
-		"UPDATE tasks SET status=?, container_id=?, started_at=?, updated_at=? WHERE id=?",
-		models.TaskStatusRunning, containerID, timeString(now), timeString(now), id,
+		"UPDATE tasks SET status=?, container_id=?, agent_image=?, started_at=?, updated_at=? WHERE id=?",
+		models.TaskStatusRunning, containerID, agentImage, now, now, id,
 	)
 	return err
 }

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -388,7 +388,7 @@ func TestSQLite_WithTx_Commit(t *testing.T) {
 		if err := tx.AssignTask(ctx, "bf_TX01"); err != nil {
 			return err
 		}
-		return tx.StartTask(ctx, "bf_TX01", "container-tx01")
+		return tx.StartTask(ctx, "bf_TX01", "container-tx01", "")
 	})
 	if err != nil {
 		t.Fatalf("WithTx: %v", err)
@@ -425,7 +425,7 @@ func TestSQLite_WithTx_Rollback(t *testing.T) {
 	// Transaction that fails — the assign should roll back
 	err := s.WithTx(ctx, func(tx Store) error {
 		tx.AssignTask(ctx, "bf_TX02")
-		tx.StartTask(ctx, "bf_TX02", "container-tx02")
+		tx.StartTask(ctx, "bf_TX02", "container-tx02", "")
 		return fmt.Errorf("something failed")
 	})
 	if err == nil {
@@ -462,7 +462,7 @@ func TestSQLite_ListTasks(t *testing.T) {
 	sqliteTestTask(t, s)
 
 	// Start the task so it becomes running
-	s.StartTask(ctx, "bf_TEST001", "container-1")
+	s.StartTask(ctx, "bf_TEST001", "container-1", "")
 
 	// List all
 	tasks, err := s.ListTasks(ctx, TaskFilter{Limit: 10})
@@ -551,7 +551,7 @@ func TestSQLite_StartTask(t *testing.T) {
 	ctx := context.Background()
 	sqliteTestTask(t, s)
 
-	if err := s.StartTask(ctx, "bf_TEST001", "container-abc"); err != nil {
+	if err := s.StartTask(ctx, "bf_TEST001", "container-abc", "skill-agent:v1"); err != nil {
 		t.Fatalf("StartTask: %v", err)
 	}
 
@@ -561,6 +561,9 @@ func TestSQLite_StartTask(t *testing.T) {
 	}
 	if got.ContainerID != "container-abc" {
 		t.Errorf("ContainerID = %q, want %q", got.ContainerID, "container-abc")
+	}
+	if got.AgentImage != "skill-agent:v1" {
+		t.Errorf("AgentImage = %q, want %q (StartTask must persist the routed image)", got.AgentImage, "skill-agent:v1")
 	}
 	if got.StartedAt == nil {
 		t.Fatal("StartedAt should be set")
@@ -666,7 +669,7 @@ func TestSQLite_RequeueTask(t *testing.T) {
 	}
 
 	s.AssignTask(ctx, task.ID)
-	s.StartTask(ctx, task.ID, "container-abc")
+	s.StartTask(ctx, task.ID, "container-abc", "")
 
 	if err := s.RequeueTask(ctx, task.ID, "container gone"); err != nil {
 		t.Fatalf("RequeueTask: %v", err)
@@ -717,7 +720,7 @@ func TestSQLite_ClearTaskAssignment(t *testing.T) {
 	sqliteTestTask(t, s)
 
 	s.AssignTask(ctx, "bf_TEST001")
-	s.StartTask(ctx, "bf_TEST001", "container-abc")
+	s.StartTask(ctx, "bf_TEST001", "container-abc", "")
 
 	if err := s.ClearTaskAssignment(ctx, "bf_TEST001"); err != nil {
 		t.Fatalf("ClearTaskAssignment: %v", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -50,7 +50,7 @@ type Store interface {
 	// Named task updates
 	UpdateTaskStatus(ctx context.Context, id string, status models.TaskStatus, taskErr string) error
 	AssignTask(ctx context.Context, id string) error
-	StartTask(ctx context.Context, id string, containerID string) error
+	StartTask(ctx context.Context, id string, containerID string, agentImage string) error
 	CompleteTask(ctx context.Context, id string, result TaskResult) error
 	RequeueTask(ctx context.Context, id string, reason string) error
 	CancelTask(ctx context.Context, id string) error


### PR DESCRIPTION
## Summary

- New `internal/orchestrator/imagerouter` deep module with a single `Resolve(task, cfg) string` function. Routing rule:
  1. `task.harness == claude_code` and `cfg.SkillAgentImage != ""` → `SkillAgentImage`
  2. read mode and `cfg.ReaderImage != ""` → `ReaderImage`
  3. else → `cfg.AgentImage`
- New `Config.SkillAgentImage` field bound to `BACKFLOW_SKILL_AGENT_IMAGE`.
- Dispatch calls the router immediately before `docker.RunAgent`, overwriting `task.AgentImage` with the resolved value. This makes the env var an effective opt-in for in-flight pending tasks, not just newly created ones.
- CLAUDE.md mentions the new env var (full docs land in Slice 7).
- Behavior is byte-for-byte identical to before when `SkillAgentImage` is unset; codex tasks ignore the new image entirely.

Closes #46.

## Test plan

- [x] `make test` (added: 15-row routing table; 2 dispatch-level tests asserting `RunAgent` sees the resolved image for claude_code and codex)
- [x] `make lint`

## Stacked PR

Stacked on top of #52 (Slice 1). Base: `slice-1-task-data-model`. Merge order: #52 → this → Slice 2.