### PR TITLE
Slice 2 (#47): Chain module — atomic self-review chained-task creation

### DIFF
--- a/docker/agent/entrypoint.sh
+++ b/docker/agent/entrypoint.sh
@@ -543,65 +543,11 @@ ${QUOTED_PROMPT}
     gh pr comment "$PR_URL" --body "$COMMENT_BODY" 2>/dev/null || true
 fi
 
-# --- Self-review phase ---
-if [ "$SELF_REVIEW" = "true" ] && [ -n "$PR_URL" ]; then
-    echo "==> Starting self-review phase..."
-
-    REVIEW_BUDGET=$(echo "$MAX_BUDGET_USD" | awk '{b = $1 * 0.2; print (b < 2) ? 2 : b}')
-
-    REVIEW_PROMPT="You are reviewing a pull request that you (a different instance) just created.
-
-PR URL: ${PR_URL}
-
-Review the PR by:
-1. Read the full diff with: gh pr diff ${PR_URL}
-2. Look at the PR description with: gh pr view ${PR_URL}
-3. Post your review using: gh pr review ${PR_URL} --comment --body '<your review>'
-
-Focus on:
-- Bugs and logic errors
-- Security issues
-- Missing error handling that could cause failures
-- Correctness of the implementation vs the PR description
-
-Do NOT comment on:
-- Code style or formatting
-- Minor naming preferences
-- Things that are working correctly
-
-You MUST post your review as a comment on the PR using the gh CLI. Do not just print your review to stdout."
-
-    REVIEW_LOG="${WORKSPACE}/review_output.log"
-    set +e
-    if [ "$HARNESS" = "codex" ]; then
-        REVIEW_CODEX_ARGS=(
-            exec
-            --model "$MODEL"
-            --dangerously-bypass-approvals-and-sandbox
-            "$REVIEW_PROMPT"
-        )
-        codex "${REVIEW_CODEX_ARGS[@]}" 2>&1 | tee "$REVIEW_LOG"
-    else
-        REVIEW_ARGS=(
-            -p "$REVIEW_PROMPT"
-            --dangerously-skip-permissions
-            --model "$MODEL"
-            --max-turns 10
-            --output-format stream-json
-            --verbose
-            --max-budget-usd "$REVIEW_BUDGET"
-        )
-        claude "${REVIEW_ARGS[@]}" 2>&1 | tee "$REVIEW_LOG"
-    fi
-    REVIEW_EXIT=${PIPESTATUS[0]}
-    set -e
-
-    if [ $REVIEW_EXIT -eq 0 ]; then
-        echo "==> Self-review completed successfully"
-    else
-        echo "==> Self-review failed (exit code: ${REVIEW_EXIT}), continuing anyway"
-    fi
-fi
+# Self-review used to happen here in the same container. It now runs as a
+# chained review task spawned by the orchestrator (internal/orchestrator/chain),
+# so this stage is intentionally empty when SELF_REVIEW=true. The "Self-Review"
+# label on the PR comment above is the user-facing hint that a follow-up review
+# task is on its way.
 
 # --- Write status ---
 ELAPSED_SEC=$(( $(date +%s) - START_TIME ))

--- a/internal/orchestrator/chain/chain.go
+++ b/internal/orchestrator/chain/chain.go
@@ -34,8 +34,15 @@ const SelfReviewBudgetUSD = 2.00
 //   - Parent completed successfully
 //   - Parent has SelfReview=true
 //   - Parent produced a non-empty PR URL
-//   - Parent is in code mode (review or read parents do not chain)
+//   - Parent is in code mode. Auto/review/read parents do not chain — by the
+//     time a task completes, the agent's prep stage has resolved auto into a
+//     concrete mode written to status.json, so an unresolved auto here means
+//     the agent never reported back and we shouldn't speculate.
 //   - Parent is itself a top-level task (no nested chains)
+//
+// MaxRuntimeSec, MaxTurns, and AgentImage are intentionally left zero on the
+// returned child; the caller fills them from review-mode config defaults
+// before persisting (chain stays config-free so it remains pure/testable).
 func Plan(parent *models.Task) (*models.Task, bool) {
 	if parent.Status != models.TaskStatusCompleted {
 		return nil, false
@@ -46,7 +53,7 @@ func Plan(parent *models.Task) (*models.Task, bool) {
 	if parent.PRURL == "" {
 		return nil, false
 	}
-	if parent.TaskMode != models.TaskModeCode && parent.TaskMode != models.TaskModeAuto {
+	if parent.TaskMode != models.TaskModeCode {
 		return nil, false
 	}
 	if parent.ParentTaskID != nil {
@@ -61,6 +68,11 @@ func Plan(parent *models.Task) (*models.Task, bool) {
 		TaskMode:     models.TaskModeReview,
 		Harness:      parent.Harness,
 		ParentTaskID: &parentID,
+		// Inherit RepoURL/Branch so dispatch has them up front. The synthesized
+		// prompt also names the PR URL, but relying solely on URL parsing for
+		// repo identity is brittle — explicit inheritance is cheap insurance.
+		RepoURL:      parent.RepoURL,
+		Branch:       parent.Branch,
 		Prompt:       synthReviewPrompt(parent),
 		Context:      parent.Context,
 		Model:        parent.Model,

--- a/internal/orchestrator/chain/chain.go
+++ b/internal/orchestrator/chain/chain.go
@@ -1,0 +1,98 @@
+// Package chain encapsulates the chained-task primitive used by self-review.
+//
+// A code task with self_review=true that completes successfully and produced
+// a PR URL gets a follow-up review task: same repo context, prompt synthesized
+// from the parent (referencing the PR URL), parent_task_id pointing at the
+// parent, and a flat $2 budget.
+//
+// Plan is a pure function — given a parent task it returns the child to insert
+// (or nothing) — so the chain rule is testable without spinning up a store.
+// Atomicity (parent COMPLETE + child INSERT in a single SQLite tx) is achieved
+// by the lifecycle.Coordinator's ChainTx hook, which runs Plan and the child
+// insert inside the same WithTx that writes the parent's terminal state.
+package chain
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/store"
+)
+
+// Flat budget applied to chained self-review tasks regardless of the parent's
+// budget. The PRD pins this at $2 to make self-review cost predictable.
+const SelfReviewBudgetUSD = 2.00
+
+// Plan returns the child review task to create for a chained self-review,
+// or (nil, false) if the parent does not qualify. Pure function — no DB
+// access. Eligibility rules:
+//
+//   - Parent completed successfully
+//   - Parent has SelfReview=true
+//   - Parent produced a non-empty PR URL
+//   - Parent is in code mode (review or read parents do not chain)
+//   - Parent is itself a top-level task (no nested chains)
+func Plan(parent *models.Task) (*models.Task, bool) {
+	if parent.Status != models.TaskStatusCompleted {
+		return nil, false
+	}
+	if !parent.SelfReview {
+		return nil, false
+	}
+	if parent.PRURL == "" {
+		return nil, false
+	}
+	if parent.TaskMode != models.TaskModeCode && parent.TaskMode != models.TaskModeAuto {
+		return nil, false
+	}
+	if parent.ParentTaskID != nil {
+		return nil, false
+	}
+
+	parentID := parent.ID
+	now := time.Now().UTC()
+	child := &models.Task{
+		ID:           "bf_" + ulid.Make().String(),
+		Status:       models.TaskStatusPending,
+		TaskMode:     models.TaskModeReview,
+		Harness:      parent.Harness,
+		ParentTaskID: &parentID,
+		Prompt:       synthReviewPrompt(parent),
+		Context:      parent.Context,
+		Model:        parent.Model,
+		Effort:       parent.Effort,
+		MaxBudgetUSD: SelfReviewBudgetUSD,
+		// Review tasks never open PRs.
+		CreatePR:        false,
+		SaveAgentOutput: parent.SaveAgentOutput,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+	return child, true
+}
+
+// synthReviewPrompt builds the chained-review prompt from the parent task. The
+// shape is intentionally simple: the agent is told what PR to review and what
+// the original code task was trying to accomplish, so it has enough context
+// to give meaningful feedback without re-deriving anything from scratch.
+func synthReviewPrompt(parent *models.Task) string {
+	return fmt.Sprintf(
+		"Review the changes in %s. The original task was: %s",
+		parent.PRURL, parent.Prompt,
+	)
+}
+
+// CreateChild inserts the child task using the supplied store. Callers that
+// want atomicity with parent completion pass the tx-scoped store from a
+// lifecycle ChainTx callback; callers that just need fire-and-forget can pass
+// the top-level store.
+func CreateChild(ctx context.Context, s store.Store, child *models.Task) error {
+	if child == nil {
+		return nil
+	}
+	return s.CreateTask(ctx, child)
+}

--- a/internal/orchestrator/chain/chain_test.go
+++ b/internal/orchestrator/chain/chain_test.go
@@ -1,0 +1,191 @@
+package chain
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/brian-bell/backlite/internal/models"
+)
+
+// TestPlan_TableDriven covers every gate condition for chained-self-review.
+func TestPlan_TableDriven(t *testing.T) {
+	tests := []struct {
+		name     string
+		parent   models.Task
+		wantNil  bool
+		wantMode string
+	}{
+		{
+			name: "happy path: code, success, self_review, has PR",
+			parent: models.Task{
+				ID:         "bf_PARENT0001",
+				Status:     models.TaskStatusCompleted,
+				TaskMode:   models.TaskModeCode,
+				Harness:    models.HarnessClaudeCode,
+				SelfReview: true,
+				PRURL:      "https://github.com/owner/repo/pull/42",
+				Prompt:     "Fix the bug",
+			},
+			wantMode: models.TaskModeReview,
+		},
+		{
+			name: "happy path inherits codex harness",
+			parent: models.Task{
+				ID:         "bf_PARENT_X",
+				Status:     models.TaskStatusCompleted,
+				TaskMode:   models.TaskModeCode,
+				Harness:    models.HarnessCodex,
+				SelfReview: true,
+				PRURL:      "https://github.com/owner/repo/pull/9",
+				Prompt:     "Fix bug",
+			},
+			wantMode: models.TaskModeReview,
+		},
+		{
+			name: "no chain: parent failed",
+			parent: models.Task{
+				ID:         "bf_FAIL00001",
+				Status:     models.TaskStatusFailed,
+				TaskMode:   models.TaskModeCode,
+				SelfReview: true,
+				PRURL:      "https://github.com/owner/repo/pull/42",
+			},
+			wantNil: true,
+		},
+		{
+			name: "no chain: parent has no PR URL",
+			parent: models.Task{
+				ID:         "bf_NOPR00001",
+				Status:     models.TaskStatusCompleted,
+				TaskMode:   models.TaskModeCode,
+				SelfReview: true,
+				PRURL:      "",
+			},
+			wantNil: true,
+		},
+		{
+			name: "no chain: self_review false",
+			parent: models.Task{
+				ID:         "bf_OFF000001",
+				Status:     models.TaskStatusCompleted,
+				TaskMode:   models.TaskModeCode,
+				SelfReview: false,
+				PRURL:      "https://github.com/owner/repo/pull/42",
+			},
+			wantNil: true,
+		},
+		{
+			name: "no chain: parent is review mode (no nested chains)",
+			parent: models.Task{
+				ID:         "bf_REVIEW001",
+				Status:     models.TaskStatusCompleted,
+				TaskMode:   models.TaskModeReview,
+				SelfReview: true,
+				PRURL:      "https://github.com/owner/repo/pull/42",
+			},
+			wantNil: true,
+		},
+		{
+			name: "no chain: parent is read mode",
+			parent: models.Task{
+				ID:         "bf_READ00001",
+				Status:     models.TaskStatusCompleted,
+				TaskMode:   models.TaskModeRead,
+				SelfReview: true,
+				PRURL:      "https://github.com/owner/repo/pull/42",
+			},
+			wantNil: true,
+		},
+		{
+			name: "no chain: parent already has parent_task_id (no recursion)",
+			parent: models.Task{
+				ID:           "bf_NESTED001",
+				Status:       models.TaskStatusCompleted,
+				TaskMode:     models.TaskModeCode,
+				SelfReview:   true,
+				PRURL:        "https://github.com/owner/repo/pull/42",
+				ParentTaskID: strPtr("bf_GRANDPARENT"),
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			child, ok := Plan(&tt.parent)
+			if tt.wantNil {
+				if ok || child != nil {
+					t.Fatalf("Plan = (%+v, %v), want (nil, false)", child, ok)
+				}
+				return
+			}
+			if !ok || child == nil {
+				t.Fatalf("Plan = (nil, %v), want non-nil child", ok)
+			}
+			if child.TaskMode != tt.wantMode {
+				t.Errorf("TaskMode = %q, want %q", child.TaskMode, tt.wantMode)
+			}
+		})
+	}
+}
+
+func TestPlan_ChildShape(t *testing.T) {
+	parent := &models.Task{
+		ID:         "bf_PARENT_BUDGET",
+		Status:     models.TaskStatusCompleted,
+		TaskMode:   models.TaskModeCode,
+		Harness:    models.HarnessClaudeCode,
+		SelfReview: true,
+		PRURL:      "https://github.com/owner/repo/pull/42",
+		Prompt:     "Refactor the auth flow.",
+		// Parent has a high budget; child should not inherit it.
+		MaxBudgetUSD: 50.0,
+		Model:        "claude-opus-4-7",
+		Effort:       "high",
+	}
+
+	child, ok := Plan(parent)
+	if !ok {
+		t.Fatalf("expected chain to produce child, got nil")
+	}
+
+	if child.ParentTaskID == nil || *child.ParentTaskID != parent.ID {
+		t.Errorf("ParentTaskID = %v, want %q", child.ParentTaskID, parent.ID)
+	}
+	if child.MaxBudgetUSD != 2.0 {
+		t.Errorf("MaxBudgetUSD = %v, want 2.0 (flat budget)", child.MaxBudgetUSD)
+	}
+	if child.TaskMode != models.TaskModeReview {
+		t.Errorf("TaskMode = %q, want review", child.TaskMode)
+	}
+	if child.Harness != parent.Harness {
+		t.Errorf("Harness = %q, want %q (inherited)", child.Harness, parent.Harness)
+	}
+	if child.Status != models.TaskStatusPending {
+		t.Errorf("Status = %q, want pending", child.Status)
+	}
+	if !strings.Contains(child.Prompt, parent.PRURL) {
+		t.Errorf("child Prompt = %q, must reference parent PR URL %q", child.Prompt, parent.PRURL)
+	}
+	if !strings.Contains(child.Prompt, parent.Prompt) {
+		t.Errorf("child Prompt = %q, must reference parent prompt %q for context", child.Prompt, parent.Prompt)
+	}
+	if !strings.HasPrefix(child.ID, "bf_") {
+		t.Errorf("child ID = %q, want bf_ prefix", child.ID)
+	}
+	if child.ID == parent.ID {
+		t.Errorf("child must have a fresh ID, got parent ID %q", child.ID)
+	}
+	if child.CreatePR {
+		t.Errorf("CreatePR = true, want false (review tasks never create PRs)")
+	}
+	// Cost-related fields on the parent must not leak into the child.
+	if child.CostUSD != 0 {
+		t.Errorf("CostUSD = %v, want 0", child.CostUSD)
+	}
+	if child.PRURL != "" {
+		t.Errorf("child PRURL = %q, want empty", child.PRURL)
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/internal/orchestrator/chain/chain_test.go
+++ b/internal/orchestrator/chain/chain_test.go
@@ -97,6 +97,20 @@ func TestPlan_TableDriven(t *testing.T) {
 			wantNil: true,
 		},
 		{
+			// Auto should have been resolved to code/review by the agent's
+			// prep stage before completion. An auto here means the agent
+			// didn't report a resolved mode — don't speculate, don't chain.
+			name: "no chain: parent mode still auto (unresolved)",
+			parent: models.Task{
+				ID:         "bf_AUTO00001",
+				Status:     models.TaskStatusCompleted,
+				TaskMode:   models.TaskModeAuto,
+				SelfReview: true,
+				PRURL:      "https://github.com/owner/repo/pull/42",
+			},
+			wantNil: true,
+		},
+		{
 			name: "no chain: parent already has parent_task_id (no recursion)",
 			parent: models.Task{
 				ID:           "bf_NESTED001",
@@ -138,6 +152,8 @@ func TestPlan_ChildShape(t *testing.T) {
 		SelfReview: true,
 		PRURL:      "https://github.com/owner/repo/pull/42",
 		Prompt:     "Refactor the auth flow.",
+		RepoURL:    "https://github.com/owner/repo",
+		Branch:     "feature-branch",
 		// Parent has a high budget; child should not inherit it.
 		MaxBudgetUSD: 50.0,
 		Model:        "claude-opus-4-7",
@@ -185,6 +201,23 @@ func TestPlan_ChildShape(t *testing.T) {
 	}
 	if child.PRURL != "" {
 		t.Errorf("child PRURL = %q, want empty", child.PRURL)
+	}
+	if child.RepoURL != parent.RepoURL {
+		t.Errorf("child RepoURL = %q, want %q (inherited)", child.RepoURL, parent.RepoURL)
+	}
+	if child.Branch != parent.Branch {
+		t.Errorf("child Branch = %q, want %q (inherited)", child.Branch, parent.Branch)
+	}
+	// MaxRuntimeSec / MaxTurns / AgentImage stay zero — caller fills from
+	// review-mode defaults before persisting.
+	if child.MaxRuntimeSec != 0 {
+		t.Errorf("child MaxRuntimeSec = %d, want 0 (caller fills from defaults)", child.MaxRuntimeSec)
+	}
+	if child.MaxTurns != 0 {
+		t.Errorf("child MaxTurns = %d, want 0 (caller fills from defaults)", child.MaxTurns)
+	}
+	if child.AgentImage != "" {
+		t.Errorf("child AgentImage = %q, want empty (caller fills from defaults)", child.AgentImage)
 	}
 }
 

--- a/internal/orchestrator/chain/lifecycle_integration_test.go
+++ b/internal/orchestrator/chain/lifecycle_integration_test.go
@@ -153,9 +153,12 @@ func TestLifecycle_Complete_WithChain_AtomicSuccess(t *testing.T) {
 	}
 }
 
-// TestLifecycle_Complete_WithChain_TxRollback verifies atomicity: if the
-// child insert fails inside the chain tx, the parent's COMPLETE rolls back
-// and the parent stays in its pre-call status.
+// TestLifecycle_Complete_WithChain_TxRollback verifies the rollback +
+// fallback contract: if the child insert fails inside the chain tx, the
+// chain tx rolls back (no child row, no task.created event), but the parent
+// still commits via a fallback CompleteTask so the user gets a normal
+// task.completed and the parent doesn't get stuck in `running` (which would
+// otherwise hot-loop on the next monitor tick).
 func TestLifecycle_Complete_WithChain_TxRollback(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()
@@ -174,37 +177,35 @@ func TestLifecycle_Complete_WithChain_TxRollback(t *testing.T) {
 			return nil, injected
 		},
 	})
-	if err == nil {
-		t.Fatalf("Complete: expected error from injected chain failure, got nil")
-	}
-	if !errors.Is(err, injected) {
-		t.Errorf("error chain = %v, want wraps %v", err, injected)
+	if err != nil {
+		t.Fatalf("Complete: expected nil after fallback succeeds, got %v", err)
 	}
 
 	gotParent, err := s.GetTask(ctx, parent.ID)
 	if err != nil {
 		t.Fatalf("GetTask parent: %v", err)
 	}
-	// Parent must still be running (rolled back), not completed.
-	if gotParent.Status != models.TaskStatusRunning {
-		t.Errorf("parent.Status after rollback = %q, want running (tx rolled back)", gotParent.Status)
+	// Fallback path commits the parent.
+	if gotParent.Status != models.TaskStatusCompleted {
+		t.Errorf("parent.Status after fallback = %q, want completed", gotParent.Status)
 	}
-	if gotParent.PRURL != "" {
-		t.Errorf("parent.PRURL after rollback = %q, want empty (tx rolled back)", gotParent.PRURL)
+	if gotParent.PRURL != "https://github.com/test/repo/pull/200" {
+		t.Errorf("parent.PRURL after fallback = %q, want PR URL set", gotParent.PRURL)
 	}
 
-	// Even on rollback, lifecycle still emits the parent's completion event so
-	// downstream consumers see the outcome. The child.created event must NOT
-	// fire because no child was persisted.
+	// Exactly one event: parent's task.completed. No child.created (chain
+	// tx rolled back, so no child row exists to announce).
 	evs := emitter.Events()
-	hasCreated := false
+	if len(evs) != 1 {
+		t.Fatalf("events = %d, want 1 (only parent.completed); got %+v", len(evs), evs)
+	}
+	if evs[0].Type != notify.EventTaskCompleted || evs[0].TaskID != parent.ID {
+		t.Errorf("event 0 = %+v, want task.completed for parent", evs[0])
+	}
 	for _, e := range evs {
 		if e.Type == notify.EventTaskCreated {
-			hasCreated = true
+			t.Errorf("task.created emitted despite chain rollback; events = %+v", evs)
 		}
-	}
-	if hasCreated {
-		t.Errorf("task.created event emitted despite rollback; events = %+v", evs)
 	}
 }
 

--- a/internal/orchestrator/chain/lifecycle_integration_test.go
+++ b/internal/orchestrator/chain/lifecycle_integration_test.go
@@ -1,0 +1,239 @@
+package chain_test
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/orchestrator/chain"
+	"github.com/brian-bell/backlite/internal/orchestrator/lifecycle"
+	"github.com/brian-bell/backlite/internal/store"
+)
+
+// captureEmitter records events for assertions.
+type captureEmitter struct {
+	mu     sync.Mutex
+	events []notify.Event
+}
+
+func (c *captureEmitter) Emit(e notify.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+}
+
+func (c *captureEmitter) Events() []notify.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]notify.Event, len(c.events))
+	copy(out, c.events)
+	return out
+}
+
+func newTestStore(t *testing.T) *store.SQLiteStore {
+	t.Helper()
+	migrationsDir := filepath.Join("..", "..", "..", "migrations")
+	dbPath := filepath.Join(t.TempDir(), "chain-test.db")
+	s, err := store.NewSQLite(context.Background(), dbPath, migrationsDir)
+	if err != nil {
+		t.Fatalf("NewSQLite: %v", err)
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func seedRunningParent(t *testing.T, s store.Store) *models.Task {
+	t.Helper()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	task := &models.Task{
+		ID:         "bf_PARENT_LIVE",
+		Status:     models.TaskStatusRunning,
+		TaskMode:   models.TaskModeCode,
+		Harness:    models.HarnessClaudeCode,
+		RepoURL:    "https://github.com/test/repo",
+		Prompt:     "Fix the auth bug",
+		SelfReview: true,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	if err := s.CreateTask(context.Background(), task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+	return task
+}
+
+// TestLifecycle_Complete_WithChain_AtomicSuccess verifies the happy path: a
+// successful self-review code task triggers atomic parent COMPLETE + child
+// INSERT, and downstream callers see two webhook events (task.completed for
+// parent, task.created for child). The child carries parent_task_id and the
+// flat $2 budget.
+func TestLifecycle_Complete_WithChain_AtomicSuccess(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	parent := seedRunningParent(t, s)
+
+	emitter := &captureEmitter{}
+	c := lifecycle.New(s, emitter)
+
+	planned, ok := chain.Plan(&models.Task{
+		ID:         parent.ID,
+		Status:     models.TaskStatusCompleted,
+		TaskMode:   parent.TaskMode,
+		Harness:    parent.Harness,
+		SelfReview: parent.SelfReview,
+		PRURL:      "https://github.com/test/repo/pull/100",
+		Prompt:     parent.Prompt,
+	})
+	if !ok || planned == nil {
+		t.Fatalf("chain.Plan returned (nil, false), want eligible child")
+	}
+
+	err := c.Complete(ctx, parent, lifecycle.Result{
+		Status:    models.TaskStatusCompleted,
+		EventType: notify.EventTaskCompleted,
+		PRURL:     "https://github.com/test/repo/pull/100",
+		EventOpts: []notify.EventOption{notify.WithContainerStatus("https://github.com/test/repo/pull/100", "", "")},
+		ChainTx: func(txCtx context.Context, tx store.Store) (*models.Task, error) {
+			return planned, chain.CreateChild(txCtx, tx, planned)
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	// Parent persisted as completed with PR URL.
+	gotParent, err := s.GetTask(ctx, parent.ID)
+	if err != nil {
+		t.Fatalf("GetTask parent: %v", err)
+	}
+	if gotParent.Status != models.TaskStatusCompleted {
+		t.Errorf("parent.Status = %q, want completed", gotParent.Status)
+	}
+	if gotParent.PRURL != "https://github.com/test/repo/pull/100" {
+		t.Errorf("parent.PRURL = %q", gotParent.PRURL)
+	}
+
+	// Child persisted with parent_task_id + flat $2 budget.
+	gotChild, err := s.GetTask(ctx, planned.ID)
+	if err != nil {
+		t.Fatalf("GetTask child: %v", err)
+	}
+	if gotChild.ParentTaskID == nil || *gotChild.ParentTaskID != parent.ID {
+		t.Errorf("child.ParentTaskID = %v, want %q", gotChild.ParentTaskID, parent.ID)
+	}
+	if gotChild.MaxBudgetUSD != chain.SelfReviewBudgetUSD {
+		t.Errorf("child.MaxBudgetUSD = %v, want %v", gotChild.MaxBudgetUSD, chain.SelfReviewBudgetUSD)
+	}
+	if gotChild.TaskMode != models.TaskModeReview {
+		t.Errorf("child.TaskMode = %q, want review", gotChild.TaskMode)
+	}
+	if gotChild.Status != models.TaskStatusPending {
+		t.Errorf("child.Status = %q, want pending", gotChild.Status)
+	}
+
+	// Two events: parent.completed, then child.created. Child event includes
+	// parent_task_id pointer.
+	evs := emitter.Events()
+	if len(evs) != 2 {
+		t.Fatalf("events = %d, want 2 (parent.completed + child.created); got %+v", len(evs), evs)
+	}
+	if evs[0].Type != notify.EventTaskCompleted || evs[0].TaskID != parent.ID {
+		t.Errorf("event 0 = %+v, want task.completed for parent", evs[0])
+	}
+	if evs[1].Type != notify.EventTaskCreated || evs[1].TaskID != planned.ID {
+		t.Errorf("event 1 = %+v, want task.created for child", evs[1])
+	}
+	if evs[1].ParentTaskID == nil || *evs[1].ParentTaskID != parent.ID {
+		t.Errorf("child event ParentTaskID = %v, want %q", evs[1].ParentTaskID, parent.ID)
+	}
+}
+
+// TestLifecycle_Complete_WithChain_TxRollback verifies atomicity: if the
+// child insert fails inside the chain tx, the parent's COMPLETE rolls back
+// and the parent stays in its pre-call status.
+func TestLifecycle_Complete_WithChain_TxRollback(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	parent := seedRunningParent(t, s)
+
+	emitter := &captureEmitter{}
+	c := lifecycle.New(s, emitter)
+
+	injected := errors.New("injected child insert failure")
+
+	err := c.Complete(ctx, parent, lifecycle.Result{
+		Status:    models.TaskStatusCompleted,
+		EventType: notify.EventTaskCompleted,
+		PRURL:     "https://github.com/test/repo/pull/200",
+		ChainTx: func(_ context.Context, _ store.Store) (*models.Task, error) {
+			return nil, injected
+		},
+	})
+	if err == nil {
+		t.Fatalf("Complete: expected error from injected chain failure, got nil")
+	}
+	if !errors.Is(err, injected) {
+		t.Errorf("error chain = %v, want wraps %v", err, injected)
+	}
+
+	gotParent, err := s.GetTask(ctx, parent.ID)
+	if err != nil {
+		t.Fatalf("GetTask parent: %v", err)
+	}
+	// Parent must still be running (rolled back), not completed.
+	if gotParent.Status != models.TaskStatusRunning {
+		t.Errorf("parent.Status after rollback = %q, want running (tx rolled back)", gotParent.Status)
+	}
+	if gotParent.PRURL != "" {
+		t.Errorf("parent.PRURL after rollback = %q, want empty (tx rolled back)", gotParent.PRURL)
+	}
+
+	// Even on rollback, lifecycle still emits the parent's completion event so
+	// downstream consumers see the outcome. The child.created event must NOT
+	// fire because no child was persisted.
+	evs := emitter.Events()
+	hasCreated := false
+	for _, e := range evs {
+		if e.Type == notify.EventTaskCreated {
+			hasCreated = true
+		}
+	}
+	if hasCreated {
+		t.Errorf("task.created event emitted despite rollback; events = %+v", evs)
+	}
+}
+
+// TestLifecycle_Complete_NoChainTx_BackwardCompatible verifies the existing
+// non-chain Complete path still works and emits exactly one event.
+func TestLifecycle_Complete_NoChainTx_BackwardCompatible(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	parent := seedRunningParent(t, s)
+
+	emitter := &captureEmitter{}
+	c := lifecycle.New(s, emitter)
+
+	err := c.Complete(ctx, parent, lifecycle.Result{
+		Status:    models.TaskStatusCompleted,
+		EventType: notify.EventTaskCompleted,
+		PRURL:     "https://github.com/test/repo/pull/300",
+	})
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	gotParent, _ := s.GetTask(ctx, parent.ID)
+	if gotParent.Status != models.TaskStatusCompleted {
+		t.Errorf("parent.Status = %q, want completed", gotParent.Status)
+	}
+
+	evs := emitter.Events()
+	if len(evs) != 1 || evs[0].Type != notify.EventTaskCompleted {
+		t.Errorf("events = %+v, want one task.completed", evs)
+	}
+}

--- a/internal/orchestrator/lifecycle/lifecycle.go
+++ b/internal/orchestrator/lifecycle/lifecycle.go
@@ -219,8 +219,9 @@ func (c *Coordinator) Complete(ctx context.Context, task *models.Task, r Result)
 	}
 
 	var (
-		writeErr   error
-		chainChild *models.Task
+		writeErr      error
+		chainChild    *models.Task
+		parentWritten bool
 	)
 	if r.ChainTx != nil {
 		// Atomic path: parent COMPLETE + chain hook (e.g. child INSERT) run in
@@ -236,15 +237,19 @@ func (c *Coordinator) Complete(ctx context.Context, task *models.Task, r Result)
 			chainChild = child
 			return nil
 		})
-		if err != nil {
-			log.Error().Err(err).Str("task_id", task.ID).Msg("lifecycle.Complete: tx (parent + chain) failed; rolling back")
-			applyTaskResult(task, storeResult, now)
-			writeErr = err
-			chainChild = nil
-		} else {
+		if err == nil {
 			c.refreshTask(ctx, task, storeResult, now)
+			parentWritten = true
+		} else {
+			// Chain tx rolled back. Fall through to the non-chain path so the
+			// parent still commits — losing the chained review is preferable
+			// to leaving the parent stuck in `running` and re-firing this code
+			// path on every monitor tick.
+			log.Warn().Err(err).Str("task_id", task.ID).Msg("lifecycle.Complete: chain tx failed; falling back to non-chain completion")
+			chainChild = nil
 		}
-	} else {
+	}
+	if !parentWritten {
 		if err := c.store.CompleteTask(ctx, task.ID, storeResult); err != nil {
 			log.Error().Err(err).Str("task_id", task.ID).Msg("lifecycle.Complete: failed to complete task in store")
 			applyTaskResult(task, storeResult, now)

--- a/internal/orchestrator/lifecycle/lifecycle.go
+++ b/internal/orchestrator/lifecycle/lifecycle.go
@@ -63,6 +63,11 @@ type Result struct {
 	// WithReading). The retry-gate option (WithReadyForRetry or
 	// WithRetryLimitReached) is applied automatically for non-success terminals.
 	EventOpts []notify.EventOption
+	// ChainTx, if non-nil, runs inside the same SQLite transaction that
+	// writes the parent's terminal state. Returning a non-nil child task
+	// causes Complete to emit task.created for it after the tx commits.
+	// Used by the chain module for atomic self-review chained-task creation.
+	ChainTx func(ctx context.Context, tx store.Store) (*models.Task, error)
 }
 
 // RequeueKind selects the event emitted when a task is returned to pending.
@@ -213,13 +218,40 @@ func (c *Coordinator) Complete(ctx context.Context, task *models.Task, r Result)
 		TaskMode:       r.TaskMode,
 	}
 
-	var writeErr error
-	if err := c.store.CompleteTask(ctx, task.ID, storeResult); err != nil {
-		log.Error().Err(err).Str("task_id", task.ID).Msg("lifecycle.Complete: failed to complete task in store")
-		applyTaskResult(task, storeResult, now)
-		writeErr = err
+	var (
+		writeErr   error
+		chainChild *models.Task
+	)
+	if r.ChainTx != nil {
+		// Atomic path: parent COMPLETE + chain hook (e.g. child INSERT) run in
+		// the same SQLite tx. If either fails, the whole pair rolls back.
+		err := c.store.WithTx(ctx, func(tx store.Store) error {
+			if err := tx.CompleteTask(ctx, task.ID, storeResult); err != nil {
+				return fmt.Errorf("complete parent: %w", err)
+			}
+			child, err := r.ChainTx(ctx, tx)
+			if err != nil {
+				return fmt.Errorf("chain tx: %w", err)
+			}
+			chainChild = child
+			return nil
+		})
+		if err != nil {
+			log.Error().Err(err).Str("task_id", task.ID).Msg("lifecycle.Complete: tx (parent + chain) failed; rolling back")
+			applyTaskResult(task, storeResult, now)
+			writeErr = err
+			chainChild = nil
+		} else {
+			c.refreshTask(ctx, task, storeResult, now)
+		}
 	} else {
-		c.refreshTask(ctx, task, storeResult, now)
+		if err := c.store.CompleteTask(ctx, task.ID, storeResult); err != nil {
+			log.Error().Err(err).Str("task_id", task.ID).Msg("lifecycle.Complete: failed to complete task in store")
+			applyTaskResult(task, storeResult, now)
+			writeErr = err
+		} else {
+			c.refreshTask(ctx, task, storeResult, now)
+		}
 	}
 
 	c.slots.Release(ctx, task)
@@ -236,6 +268,9 @@ func (c *Coordinator) Complete(ctx context.Context, task *models.Task, r Result)
 		}
 	}
 	c.emitter.Emit(notify.NewEvent(r.EventType, task, opts...))
+	if chainChild != nil {
+		c.emitter.Emit(notify.NewEvent(notify.EventTaskCreated, chainChild))
+	}
 	return writeErr
 }
 

--- a/internal/orchestrator/monitor.go
+++ b/internal/orchestrator/monitor.go
@@ -9,6 +9,7 @@ import (
 	"github.com/oklog/ulid/v2"
 	"github.com/rs/zerolog/log"
 
+	"github.com/brian-bell/backlite/internal/config"
 	"github.com/brian-bell/backlite/internal/models"
 	"github.com/brian-bell/backlite/internal/notify"
 	"github.com/brian-bell/backlite/internal/orchestrator/chain"
@@ -182,6 +183,25 @@ func (o *Orchestrator) handleCompletion(ctx context.Context, task *models.Task, 
 			projected.TaskMode = result.TaskMode
 		}
 		if child, ok := chain.Plan(&projected); ok {
+			// Plan leaves MaxRuntimeSec/MaxTurns/AgentImage zero — fill them
+			// from review-mode defaults so the chained task gets bounded
+			// runtime/turn caps. Force CreatePR=false and SelfReview=false on
+			// the child (the recursion guard in Plan covers SelfReview, but
+			// being explicit avoids picking up the global default), and pin
+			// SaveAgentOutput to whatever the parent had so we don't drift to
+			// the global default for chained children.
+			falseVal := false
+			saveOutput := projected.SaveAgentOutput
+			o.config.TaskDefaults(models.TaskModeReview).Apply(child, &config.BoolOverrides{
+				CreatePR:        &falseVal,
+				SelfReview:      &falseVal,
+				SaveAgentOutput: &saveOutput,
+			})
+			log.Info().
+				Str("parent_task_id", task.ID).
+				Str("child_task_id", child.ID).
+				Str("pr_url", result.PRURL).
+				Msg("self-review chain planned")
 			result.ChainTx = func(txCtx context.Context, tx store.Store) (*models.Task, error) {
 				return child, chain.CreateChild(txCtx, tx, child)
 			}

--- a/internal/orchestrator/monitor.go
+++ b/internal/orchestrator/monitor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/brian-bell/backlite/internal/models"
 	"github.com/brian-bell/backlite/internal/notify"
+	"github.com/brian-bell/backlite/internal/orchestrator/chain"
 	"github.com/brian-bell/backlite/internal/orchestrator/lifecycle"
 	"github.com/brian-bell/backlite/internal/store"
 )
@@ -165,6 +166,26 @@ func (o *Orchestrator) handleCompletion(ctx context.Context, task *models.Task, 
 		result.EventOpts = []notify.EventOption{notify.WithContainerStatus("", status.Question, status.LogTail)}
 	default:
 		result.EventOpts = []notify.EventOption{notify.WithContainerStatus("", result.Error, status.LogTail)}
+	}
+
+	// Chain self-review on a successful code task. We pre-compute the child
+	// from the projected post-completion parent state and let lifecycle.Complete
+	// run the parent COMPLETE + child INSERT atomically.
+	if result.Status == models.TaskStatusCompleted {
+		projected := *task
+		projected.Status = models.TaskStatusCompleted
+		projected.PRURL = result.PRURL
+		if result.RepoURL != "" {
+			projected.RepoURL = result.RepoURL
+		}
+		if result.TaskMode != "" {
+			projected.TaskMode = result.TaskMode
+		}
+		if child, ok := chain.Plan(&projected); ok {
+			result.ChainTx = func(txCtx context.Context, tx store.Store) (*models.Task, error) {
+				return child, chain.CreateChild(txCtx, tx, child)
+			}
+		}
 	}
 
 	if err := o.lifecycle.Complete(ctx, task, result); err != nil {

--- a/internal/orchestrator/monitor_test.go
+++ b/internal/orchestrator/monitor_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/brian-bell/backlite/internal/models"
 	"github.com/brian-bell/backlite/internal/notify"
 	"github.com/brian-bell/backlite/internal/orchestrator/outputs"
+	"github.com/brian-bell/backlite/internal/store"
 )
 
 func TestMonitorCancelled_DecrementsRunning(t *testing.T) {
@@ -196,6 +197,120 @@ func TestHandleCompletion_Success(t *testing.T) {
 	types := n.eventTypes()
 	if len(types) != 1 || types[0] != notify.EventTaskCompleted {
 		t.Errorf("expected [task.completed], got %v", types)
+	}
+}
+
+// TestHandleCompletion_SelfReview_ChainsReviewTask covers the end-to-end
+// self-review chain via handleCompletion: a successful code task with
+// SelfReview=true and a non-empty PR URL produces a child review task with
+// the parent's PR URL synthesized into its prompt.
+func TestHandleCompletion_SelfReview_ChainsReviewTask(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_selfrev",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeCode,
+		Harness:     models.HarnessClaudeCode,
+		RepoURL:     "https://github.com/test/repo",
+		Prompt:      "Refactor auth handler",
+		SelfReview:  true,
+		ContainerID: "cont-self",
+		StartedAt:   &now,
+	})
+
+	bus, n := newTestBus()
+	o := newTestOrchestrator(s, bus)
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_selfrev")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:     true,
+		ExitCode: 0,
+		PRURL:    "https://github.com/test/repo/pull/77",
+	})
+	bus.Close()
+
+	// Parent persisted as completed.
+	parent, _ := s.GetTask(context.Background(), "bf_selfrev")
+	if parent.Status != models.TaskStatusCompleted {
+		t.Errorf("parent.Status = %q, want completed", parent.Status)
+	}
+
+	// One child task should exist with the right shape.
+	tasks, _ := s.ListTasks(context.Background(), store.TaskFilter{})
+	var child *models.Task
+	for _, t2 := range tasks {
+		if t2.ID == parent.ID {
+			continue
+		}
+		child = t2
+	}
+	if child == nil {
+		t.Fatalf("no child task created; tasks = %+v", tasks)
+	}
+	if child.TaskMode != models.TaskModeReview {
+		t.Errorf("child.TaskMode = %q, want review", child.TaskMode)
+	}
+	if child.ParentTaskID == nil || *child.ParentTaskID != parent.ID {
+		t.Errorf("child.ParentTaskID = %v, want %q", child.ParentTaskID, parent.ID)
+	}
+	if child.MaxBudgetUSD != 2.0 {
+		t.Errorf("child.MaxBudgetUSD = %v, want 2.0", child.MaxBudgetUSD)
+	}
+	if child.Harness != models.HarnessClaudeCode {
+		t.Errorf("child.Harness = %q, want claude_code (inherited)", child.Harness)
+	}
+
+	// Two events: parent.completed, child.created. Order matters.
+	types := n.eventTypes()
+	if len(types) != 2 {
+		t.Fatalf("event types = %v, want [task.completed, task.created]", types)
+	}
+	if types[0] != notify.EventTaskCompleted {
+		t.Errorf("event 0 = %q, want task.completed", types[0])
+	}
+	if types[1] != notify.EventTaskCreated {
+		t.Errorf("event 1 = %q, want task.created", types[1])
+	}
+}
+
+// TestHandleCompletion_SelfReview_NoPR_NoChain pins that a successful code
+// task without a PR URL doesn't trigger a chain (PR URL is the contract).
+func TestHandleCompletion_SelfReview_NoPR_NoChain(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_nopr",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeCode,
+		Harness:     models.HarnessClaudeCode,
+		RepoURL:     "https://github.com/test/repo",
+		Prompt:      "Refactor",
+		SelfReview:  true,
+		ContainerID: "cont-nopr",
+		StartedAt:   &now,
+	})
+
+	bus, n := newTestBus()
+	o := newTestOrchestrator(s, bus)
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_nopr")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:     true,
+		ExitCode: 0,
+		PRURL:    "",
+	})
+	bus.Close()
+
+	tasks, _ := s.ListTasks(context.Background(), store.TaskFilter{})
+	if len(tasks) != 1 {
+		t.Fatalf("tasks = %d, want 1 (no chain when no PR URL)", len(tasks))
+	}
+	types := n.eventTypes()
+	if len(types) != 1 || types[0] != notify.EventTaskCompleted {
+		t.Errorf("event types = %v, want [task.completed] only", types)
 	}
 }
 


### PR DESCRIPTION
## Summary

- New `internal/orchestrator/chain` deep module:
  - `Plan(parent) -> (child, ok)` — pure decision function. Eligibility: parent completed successfully, `SelfReview=true`, non-empty PR URL, code-mode, not itself a chained task. Child shape: review mode, parent_task_id pointing at parent, flat $2 budget, harness inherited, prompt synthesized from parent PR URL + parent prompt for context.
  - `CreateChild` — thin tx-scoped store wrapper.
- `lifecycle.Result.ChainTx` callback runs inside the same SQLite tx as the parent's `CompleteTask`. Atomicity verified by an injected-failure test (child insert fails → parent's COMPLETE rolls back; no `task.created` event emitted).
- `monitor.handleCompletion` plans the chain on successful code-task completion and wires it into the lifecycle `Result`.
- Two webhook events fire on chain success: `task.completed` (parent), then `task.created` (child) carrying `parent_task_id`.

Closes #47.

## Test plan

- [x] `make test`
  - `chain.Plan` table-driven with 8 eligibility rows + child-shape assertions
  - lifecycle integration: atomic success, tx rollback under injected failure, backwards-compatible no-chain path
  - `monitor.handleCompletion` end-to-end via mock store: chain materializes; missing PR URL = no chain
- [x] `make lint`

## Stacked PR

Stacked on #53 (Slice 3). Base: `slice-3-image-router`. Merge order: #52 → #53 → this → Slice 4.