### PR TITLE
[backlite] Add local SQLite backup worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ GITHUB_TOKEN=ghp_...
 BACKFLOW_LISTEN_ADDR=:8080
 BACKFLOW_DATABASE_PATH=./backlite.db
 
+# Local SQLite backups (enabled by default)
+# BACKFLOW_LOCAL_BACKUP_ENABLED=true
+# BACKFLOW_LOCAL_BACKUP_DIR=~/backlite-backups
+# BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC=86400
+
 # Agent image (set this if you publish a non-default tag; use backlite-fake-agent for local blackbox/soak testing)
 # BACKFLOW_AGENT_IMAGE=backlite-fake-agent
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ All JSON responses are wrapped in a `{"data": …}` envelope; errors use `{"erro
 - **config/** — Env-var config (`BACKFLOW_*` prefix). `BACKFLOW_API_KEY` enables single-token API auth; otherwise `api_keys` in SQLite can back authenticated API/debug requests. `TaskDefaults(taskMode)` returns resolved defaults — for `read` mode it swaps in `ReaderImage` plus the `BACKFLOW_DEFAULT_READ_MAX_*` caps. `Apply(task, overrides)` fills zero-value fields using `*bool` overrides (nil = use default, non-nil = use pointed value). `Load()` enforces an all-or-nothing gate on the email-notification trio (`BACKFLOW_RESEND_API_KEY`, `BACKFLOW_NOTIFY_EMAIL_FROM`, `BACKFLOW_NOTIFY_EMAIL_TO`): setting any one of them without the other two fails startup.
 - **notify/** — `Notifier` interface, `WebhookNotifier` (HTTP POST, 3 retries, event filtering), `NoopNotifier`, `EventBus` (async fan-out delivery via buffered channel), `NewEvent` constructor with `EventOption` functional options (including `WithReading` for read-mode completion events). `Event` carries `TaskMode`, `ParentTaskID` (when set), plus optional reading fields (`TLDR`, `NoveltyVerdict`, `Tags`, `Connections`) populated only for read-task completion events.
 - **debug/** — `/debug/stats` handler: PID, uptime, running task count, database handle metrics
+- **backup/** — Local SQLite backup manager. `Manager.MaybeSchedule(ctx)` is invoked from each orchestrator tick; when enabled and the latest valid artifact is older than the configured interval, it spawns a single background goroutine that uses the SQLite online-backup API, gzip-compresses the snapshot, decompresses + `PRAGMA integrity_check`s it, then atomically renames into place and writes a sidecar with size, sha256, and finalization time. Subsequent ticks recompute the sha256 of the latest candidate before trusting it; mismatches fall back to the next-older valid artifact.
 - **skillcontract/** — Embedded JSON Schema validator (`schema.json`) for skill-agent `status.json` payloads. Tests walk every `docker/skill-agent/skills/*/examples/status.json` fixture and assert the deliberately broken negative fixture fails. Used by the skill-agent build to keep skill bundles' contract test fixtures honest.
 
 ### Web app (`web/`)
@@ -164,6 +165,27 @@ Reading-mode env vars:
 `BACKFLOW_SKILL_AGENT_IMAGE` opts a deployment into the `docker/skill-agent/` image (claude_code-only). See **Agent containers — three coexisting images** above for the routing rule and the absent-from-this-image components (`status_writer.sh`, `reader_helpers.sh`, prep stage, in-container retry loop). Skill bundles live in the source tree at `docker/skill-agent/skills/{auto,code,review,read}/`; the entrypoint copies the requested bundle into `~/.claude/skills/<mode>/` at start so Claude Code's native skill loader picks it up. The `auto` bundle dispatches at runtime to `code` or `review`, so the entrypoint installs both sub-bundles alongside it. The `status.json` contract is enforced by the Go validator in `internal/skillcontract`, which embeds `schema.json` and walks every `docker/skill-agent/skills/*/examples/status.json` fixture in tests. Skills are not a user-facing extension point — operators do not supply or override skill content per task.
 
 The `tasks` table carries a `force` boolean column. REST callers can set `force` on `POST /api/v1/tasks`; `Force=true` bypasses the dispatch-time duplicate check and allows an existing reading row to be overwritten on completion.
+
+## Local SQLite backups
+
+Enabled by default. Each orchestrator tick calls `backup.Manager.MaybeSchedule(ctx)`; the manager exits early if disabled, already running, or the latest valid backup is younger than `BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC`. Otherwise it launches a single background goroutine that:
+
+1. Opens the configured database read-side and runs the SQLite online backup API (`*sqlite.Backup` from `modernc.org/sqlite`) into a temp file.
+2. Gzip-compresses the temp file to a `.sqlite.gz.tmp` sibling.
+3. Decompresses to a verification temp file and runs `PRAGMA integrity_check`.
+4. Hashes the compressed bytes, `os.Rename`s the gzip into place, then atomically writes a `.meta.json` sidecar containing `file_name`, `created_at` (scheduled), `finalized_at` (post-rename), `sha256`, and `size_bytes`.
+
+Artifact filenames are `backlite-YYYYMMDDTHHMMSSZ.sqlite.gz` (UTC). Age comparisons use `finalized_at` so a backup that takes longer than the interval does not immediately appear stale and trigger a continuous loop. Validity requires a structurally-correct sidecar **and** a recomputed sha256 that matches; corrupted artifacts are skipped and the scheduler falls back to the next-older valid one.
+
+Failures (e.g. integrity check fails, disk full, source DB locked beyond `busy_timeout`) are logged and do not affect health checks or task orchestration. Backup work runs concurrently with task orchestration but `MaybeSchedule` enforces single-flight via a mutex.
+
+Env vars (see `internal/config/config.go` for current defaults):
+
+- `BACKFLOW_LOCAL_BACKUP_ENABLED` — toggle the worker (default on)
+- `BACKFLOW_LOCAL_BACKUP_DIR` — output directory; supports `~` expansion
+- `BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC` — minimum spacing between successful backups
+
+Restore is manual: stop the server, copy the chosen `.sqlite.gz` aside, `gunzip` it, optionally re-run `PRAGMA integrity_check`, replace the file at `BACKFLOW_DATABASE_PATH`, and restart.
 
 ## Email summary delivery (read mode, opt-in)
 

--- a/README.md
+++ b/README.md
@@ -300,3 +300,15 @@ Optional Resend integration that emails a structured summary of every completed 
 | Variable | Description |
 |----------|-------------|
 | `BACKFLOW_WEB_DIR` | Directory of the prebuilt web bundle served at `/*` (defaults to `./web/dist`). Leave the directory empty to disable the SPA route. |
+
+### Local SQLite backups
+
+Enabled by default. The server runs a single background worker from the orchestrator tick that takes a consistent online SQLite snapshot, gzip-compresses and verifies it, and writes it into a configurable directory alongside a `.meta.json` sidecar (`file_name`, `created_at`, `finalized_at`, `sha256`, `size_bytes`). Artifacts are named `backlite-YYYYMMDDTHHMMSSZ.sqlite.gz`. The latest artifact's sha256 is recomputed each tick before it is trusted; corrupted artifacts are skipped and the scheduler falls back to the previous valid one. Backup failures are logged and do not affect health checks or task orchestration.
+
+| Variable | Description |
+|----------|-------------|
+| `BACKFLOW_LOCAL_BACKUP_ENABLED` | Toggle the local backup worker |
+| `BACKFLOW_LOCAL_BACKUP_DIR` | Output directory (supports `~` expansion) |
+| `BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC` | Minimum spacing between successful backups |
+
+To restore: stop the server, `gunzip backlite-...sqlite.gz`, optionally `sqlite3 file.sqlite "PRAGMA integrity_check;"`, copy the result over the file at `BACKFLOW_DATABASE_PATH`, and restart.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -121,6 +121,7 @@ ls "$BACKFLOW_DATA_DIR/tasks/<task-id>/"
 - Concurrency capacity is capped by `BACKFLOW_MAX_CONTAINERS`; the orchestrator counts tasks in `provisioning`/`running` against it.
 - `save_agent_output=false` disables the filesystem artifact write for a task.
 - The reading-library SPA is served at `/`. Visit `http://<host>:8080/` after `make build && make run` to browse stored readings; paste a bearer token into the topbar form when API keys are configured.
+- Local SQLite backups are on by default and write `backlite-YYYYMMDDTHHMMSSZ.sqlite.gz` artifacts plus `.meta.json` sidecars under `BACKFLOW_LOCAL_BACKUP_DIR`. Mount that directory on persistent storage (and consider snapshotting/replicating it off-host). Disable with `BACKFLOW_LOCAL_BACKUP_ENABLED=false` if you back the database up some other way. Restore is documented in the README.
 
 ## Related Docs
 

--- a/internal/backup/manager.go
+++ b/internal/backup/manager.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -20,7 +21,7 @@ import (
 )
 
 const (
-	artifactPrefix    = "backflow-"
+	artifactPrefix    = "backlite-"
 	artifactExtension = ".sqlite.gz"
 	metadataExtension = ".meta.json"
 	timestampLayout   = "20060102T150405Z"
@@ -35,10 +36,11 @@ type Config struct {
 }
 
 type Metadata struct {
-	FileName  string    `json:"file_name"`
-	CreatedAt time.Time `json:"created_at"`
-	SHA256    string    `json:"sha256"`
-	SizeBytes int64     `json:"size_bytes"`
+	FileName    string    `json:"file_name"`
+	CreatedAt   time.Time `json:"created_at"`
+	FinalizedAt time.Time `json:"finalized_at"`
+	SHA256      string    `json:"sha256"`
+	SizeBytes   int64     `json:"size_bytes"`
 }
 
 type Artifact struct {
@@ -148,7 +150,18 @@ func (m *Manager) needsBackup() (bool, *Artifact, error) {
 	if latest == nil {
 		return true, nil, nil
 	}
-	return m.now().UTC().Sub(latest.Timestamp) >= m.cfg.Interval, latest, nil
+	return m.now().UTC().Sub(latest.ageReference()) >= m.cfg.Interval, latest, nil
+}
+
+// ageReference is the timestamp the scheduler uses to decide whether an
+// artifact is older than the configured interval. Prefer the finalization
+// time so a backup that takes longer than the interval does not immediately
+// look stale on the next tick.
+func (a *Artifact) ageReference() time.Time {
+	if !a.Metadata.FinalizedAt.IsZero() {
+		return a.Metadata.FinalizedAt
+	}
+	return a.Timestamp
 }
 
 func (m *Manager) findLatestValidArtifact() (*Artifact, error) {
@@ -160,39 +173,77 @@ func (m *Manager) findLatestValidArtifact() (*Artifact, error) {
 		return nil, fmt.Errorf("read backup directory: %w", err)
 	}
 
-	var latest *Artifact
+	type candidate struct {
+		path     string
+		metaPath string
+		ts       time.Time
+	}
+	var candidates []candidate
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue
 		}
-
-		name := entry.Name()
-		ts, ok := parseArtifactTimestamp(name)
+		ts, ok := parseArtifactTimestamp(entry.Name())
 		if !ok {
 			continue
 		}
+		artifactPath := filepath.Join(m.cfg.Directory, entry.Name())
+		candidates = append(candidates, candidate{
+			path:     artifactPath,
+			metaPath: metadataPath(artifactPath),
+			ts:       ts,
+		})
+	}
 
-		artifactPath := filepath.Join(m.cfg.Directory, name)
-		metadataPath := metadataPath(artifactPath)
-		meta, valid, err := readMetadata(artifactPath, metadataPath)
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ts.After(candidates[j].ts)
+	})
+
+	for _, c := range candidates {
+		meta, valid, err := readMetadata(c.path, c.metaPath)
 		if err != nil {
 			return nil, err
 		}
 		if !valid {
 			continue
 		}
-
-		if latest == nil || ts.After(latest.Timestamp) {
-			latest = &Artifact{
-				Path:         artifactPath,
-				MetadataPath: metadataPath,
-				Timestamp:    ts,
-				Metadata:     meta,
-			}
+		if err := verifyArtifactChecksum(c.path, meta.SHA256); err != nil {
+			log.Warn().
+				Err(err).
+				Str("artifact", c.path).
+				Msg("backup artifact failed checksum verification; skipping")
+			continue
 		}
+		return &Artifact{
+			Path:         c.path,
+			MetadataPath: c.metaPath,
+			Timestamp:    c.ts,
+			Metadata:     meta,
+		}, nil
 	}
 
-	return latest, nil
+	return nil, nil
+}
+
+func verifyArtifactChecksum(path string, expected string) error {
+	if expected == "" {
+		return fmt.Errorf("missing expected sha256")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("open artifact for checksum verification: %w", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	if _, err := io.Copy(hash, file); err != nil {
+		return fmt.Errorf("hash artifact for verification: %w", err)
+	}
+	actual := hex.EncodeToString(hash.Sum(nil))
+	if actual != expected {
+		return fmt.Errorf("sha256 mismatch: expected %s, got %s", expected, actual)
+	}
+	return nil
 }
 
 func (m *Manager) runBackup(ctx context.Context, startedAt time.Time) error {
@@ -235,6 +286,7 @@ func (m *Manager) runBackup(ctx context.Context, startedAt time.Time) error {
 	if err := os.Rename(gzipTmpPath, finalPath); err != nil {
 		return fmt.Errorf("finalize backup artifact: %w", err)
 	}
+	meta.FinalizedAt = m.now().UTC().Truncate(time.Second)
 	if err := writeMetadata(metadataTmpPath, metadataPath(finalPath), meta); err != nil {
 		_ = os.Remove(finalPath)
 		return err

--- a/internal/backup/manager.go
+++ b/internal/backup/manager.go
@@ -1,0 +1,529 @@
+package backup
+
+import (
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"modernc.org/sqlite"
+)
+
+const (
+	artifactPrefix    = "backflow-"
+	artifactExtension = ".sqlite.gz"
+	metadataExtension = ".meta.json"
+	timestampLayout   = "20060102T150405Z"
+	backupStepPages   = 128
+)
+
+type Config struct {
+	Enabled      bool
+	DatabasePath string
+	Directory    string
+	Interval     time.Duration
+}
+
+type Metadata struct {
+	FileName  string    `json:"file_name"`
+	CreatedAt time.Time `json:"created_at"`
+	SHA256    string    `json:"sha256"`
+	SizeBytes int64     `json:"size_bytes"`
+}
+
+type Artifact struct {
+	Path         string
+	MetadataPath string
+	Timestamp    time.Time
+	Metadata     Metadata
+}
+
+type Manager struct {
+	cfg Config
+
+	mu      sync.Mutex
+	running bool
+
+	now         func() time.Time
+	runBackupFn func(context.Context, time.Time) error
+}
+
+func New(cfg Config) *Manager {
+	m := &Manager{
+		cfg: cfg,
+		now: time.Now,
+	}
+	m.runBackupFn = m.runBackup
+	return m
+}
+
+// MaybeSchedule starts a single background backup worker when local backups are
+// enabled and the latest finalized artifact is older than the configured
+// interval. The call is non-blocking; backup work runs in a goroutine.
+func (m *Manager) MaybeSchedule(ctx context.Context) {
+	if !m.cfg.Enabled {
+		return
+	}
+	if m.isRunning() {
+		return
+	}
+
+	due, latest, err := m.needsBackup()
+	if err != nil {
+		log.Error().
+			Err(err).
+			Str("backup_dir", m.cfg.Directory).
+			Msg("failed to inspect local backup state")
+		return
+	}
+	if !due {
+		return
+	}
+
+	startedAt := m.now().UTC().Truncate(time.Second)
+
+	m.mu.Lock()
+	if m.running {
+		m.mu.Unlock()
+		return
+	}
+	m.running = true
+	m.mu.Unlock()
+
+	go func() {
+		defer m.setRunning(false)
+
+		logger := log.Info().
+			Str("backup_dir", m.cfg.Directory).
+			Str("database_path", m.cfg.DatabasePath)
+		if latest != nil {
+			logger = logger.Time("previous_backup_at", latest.Timestamp)
+		}
+		logger.Time("scheduled_at", startedAt).Msg("starting local sqlite backup")
+
+		if err := m.runBackupFn(ctx, startedAt); err != nil {
+			log.Error().
+				Err(err).
+				Str("backup_dir", m.cfg.Directory).
+				Str("database_path", m.cfg.DatabasePath).
+				Msg("local sqlite backup failed")
+			return
+		}
+
+		log.Info().
+			Str("backup_dir", m.cfg.Directory).
+			Str("database_path", m.cfg.DatabasePath).
+			Time("backup_at", startedAt).
+			Msg("local sqlite backup completed")
+	}()
+}
+
+func (m *Manager) isRunning() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.running
+}
+
+func (m *Manager) setRunning(v bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.running = v
+}
+
+func (m *Manager) needsBackup() (bool, *Artifact, error) {
+	latest, err := m.findLatestValidArtifact()
+	if err != nil {
+		return false, nil, err
+	}
+	if latest == nil {
+		return true, nil, nil
+	}
+	return m.now().UTC().Sub(latest.Timestamp) >= m.cfg.Interval, latest, nil
+}
+
+func (m *Manager) findLatestValidArtifact() (*Artifact, error) {
+	entries, err := os.ReadDir(m.cfg.Directory)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read backup directory: %w", err)
+	}
+
+	var latest *Artifact
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		ts, ok := parseArtifactTimestamp(name)
+		if !ok {
+			continue
+		}
+
+		artifactPath := filepath.Join(m.cfg.Directory, name)
+		metadataPath := metadataPath(artifactPath)
+		meta, valid, err := readMetadata(artifactPath, metadataPath)
+		if err != nil {
+			return nil, err
+		}
+		if !valid {
+			continue
+		}
+
+		if latest == nil || ts.After(latest.Timestamp) {
+			latest = &Artifact{
+				Path:         artifactPath,
+				MetadataPath: metadataPath,
+				Timestamp:    ts,
+				Metadata:     meta,
+			}
+		}
+	}
+
+	return latest, nil
+}
+
+func (m *Manager) runBackup(ctx context.Context, startedAt time.Time) error {
+	if err := os.MkdirAll(m.cfg.Directory, 0o755); err != nil {
+		return fmt.Errorf("create backup directory: %w", err)
+	}
+
+	finalPath, rawTmpPath, gzipTmpPath, metadataTmpPath, err := m.preparePaths(startedAt)
+	if err != nil {
+		return err
+	}
+
+	verifyTmpPath := gzipTmpPath + ".verify"
+	for _, path := range []string{rawTmpPath, gzipTmpPath, metadataTmpPath, verifyTmpPath} {
+		if err := removeIfExists(path); err != nil {
+			return err
+		}
+	}
+	defer func() {
+		for _, path := range []string{rawTmpPath, gzipTmpPath, metadataTmpPath, verifyTmpPath} {
+			_ = os.Remove(path)
+		}
+	}()
+
+	if err := onlineBackup(ctx, m.cfg.DatabasePath, rawTmpPath); err != nil {
+		return err
+	}
+	if err := compressFile(rawTmpPath, gzipTmpPath); err != nil {
+		return err
+	}
+	if err := validateCompressedSQLiteBackup(ctx, gzipTmpPath, verifyTmpPath); err != nil {
+		return err
+	}
+
+	meta, err := describeArtifact(gzipTmpPath, filepath.Base(finalPath), startedAt)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Rename(gzipTmpPath, finalPath); err != nil {
+		return fmt.Errorf("finalize backup artifact: %w", err)
+	}
+	if err := writeMetadata(metadataTmpPath, metadataPath(finalPath), meta); err != nil {
+		_ = os.Remove(finalPath)
+		return err
+	}
+
+	return nil
+}
+
+func (m *Manager) preparePaths(startedAt time.Time) (string, string, string, string, error) {
+	timestamp := startedAt.UTC()
+
+	for i := 0; i < 120; i++ {
+		baseName := artifactPrefix + timestamp.Format(timestampLayout) + artifactExtension
+		finalPath := filepath.Join(m.cfg.Directory, baseName)
+		if _, err := os.Stat(finalPath); err == nil {
+			timestamp = timestamp.Add(time.Second)
+			continue
+		} else if !os.IsNotExist(err) {
+			return "", "", "", "", fmt.Errorf("inspect backup artifact path: %w", err)
+		}
+
+		rawTmpPath := finalPath + ".sqlite.tmp"
+		gzipTmpPath := finalPath + ".tmp"
+		metadataTmpPath := metadataPath(finalPath) + ".tmp"
+		return finalPath, rawTmpPath, gzipTmpPath, metadataTmpPath, nil
+	}
+
+	return "", "", "", "", fmt.Errorf("failed to allocate unique backup artifact path")
+}
+
+func onlineBackup(ctx context.Context, sourcePath string, destinationPath string) error {
+	if _, err := os.Stat(sourcePath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("source sqlite database does not exist: %s", sourcePath)
+		}
+		return fmt.Errorf("stat source sqlite database: %w", err)
+	}
+
+	db, err := sql.Open("sqlite", sourcePath)
+	if err != nil {
+		return fmt.Errorf("open sqlite source database: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
+
+	if _, err := db.ExecContext(ctx, "PRAGMA busy_timeout = 5000"); err != nil {
+		return fmt.Errorf("set backup busy timeout: %w", err)
+	}
+
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("acquire sqlite source connection: %w", err)
+	}
+	defer conn.Close()
+
+	return conn.Raw(func(driverConn any) error {
+		rawConn, ok := driverConn.(interface {
+			NewBackup(string) (*sqlite.Backup, error)
+		})
+		if !ok {
+			return fmt.Errorf("sqlite driver does not expose online backup support")
+		}
+
+		backup, err := rawConn.NewBackup(destinationPath)
+		if err != nil {
+			return fmt.Errorf("initialize sqlite online backup: %w", err)
+		}
+
+		finished := false
+		defer func() {
+			if !finished {
+				_ = backup.Finish()
+				_ = os.Remove(destinationPath)
+			}
+		}()
+
+		for {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+
+			more, err := backup.Step(backupStepPages)
+			if err != nil {
+				return fmt.Errorf("step sqlite online backup: %w", err)
+			}
+			if !more {
+				break
+			}
+		}
+
+		if err := backup.Finish(); err != nil {
+			return fmt.Errorf("finish sqlite online backup: %w", err)
+		}
+		finished = true
+		return nil
+	})
+}
+
+func compressFile(sourcePath string, destinationPath string) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open raw backup for compression: %w", err)
+	}
+	defer source.Close()
+
+	destination, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("create compressed backup artifact: %w", err)
+	}
+	defer destination.Close()
+
+	gz := gzip.NewWriter(destination)
+	if _, err := io.Copy(gz, source); err != nil {
+		gz.Close()
+		return fmt.Errorf("compress backup artifact: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("close gzip writer: %w", err)
+	}
+	if err := destination.Close(); err != nil {
+		return fmt.Errorf("close compressed backup artifact: %w", err)
+	}
+
+	return nil
+}
+
+func validateCompressedSQLiteBackup(ctx context.Context, compressedPath string, verifyPath string) error {
+	if err := decompressFile(compressedPath, verifyPath); err != nil {
+		return err
+	}
+	if err := validateSQLiteDatabase(ctx, verifyPath); err != nil {
+		return err
+	}
+	return nil
+}
+
+func decompressFile(sourcePath string, destinationPath string) error {
+	source, err := os.Open(sourcePath)
+	if err != nil {
+		return fmt.Errorf("open compressed backup artifact: %w", err)
+	}
+	defer source.Close()
+
+	reader, err := gzip.NewReader(source)
+	if err != nil {
+		return fmt.Errorf("open gzip reader for backup artifact: %w", err)
+	}
+	defer reader.Close()
+
+	destination, err := os.OpenFile(destinationPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("create verification sqlite file: %w", err)
+	}
+	defer destination.Close()
+
+	if _, err := io.Copy(destination, reader); err != nil {
+		return fmt.Errorf("decompress backup artifact: %w", err)
+	}
+	if err := destination.Close(); err != nil {
+		return fmt.Errorf("close verification sqlite file: %w", err)
+	}
+
+	return nil
+}
+
+func validateSQLiteDatabase(ctx context.Context, databasePath string) error {
+	db, err := sql.Open("sqlite", databasePath)
+	if err != nil {
+		return fmt.Errorf("open verification sqlite database: %w", err)
+	}
+	defer db.Close()
+
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	db.SetConnMaxLifetime(0)
+
+	var result string
+	if err := db.QueryRowContext(ctx, "PRAGMA integrity_check").Scan(&result); err != nil {
+		return fmt.Errorf("run sqlite integrity_check: %w", err)
+	}
+	if result != "ok" {
+		return fmt.Errorf("sqlite integrity_check failed: %s", result)
+	}
+	return nil
+}
+
+func describeArtifact(path string, fileName string, createdAt time.Time) (Metadata, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Metadata{}, fmt.Errorf("open compressed artifact for metadata: %w", err)
+	}
+	defer file.Close()
+
+	hash := sha256.New()
+	size, err := io.Copy(hash, file)
+	if err != nil {
+		return Metadata{}, fmt.Errorf("hash compressed artifact: %w", err)
+	}
+
+	return Metadata{
+		FileName:  fileName,
+		CreatedAt: createdAt.UTC(),
+		SHA256:    hex.EncodeToString(hash.Sum(nil)),
+		SizeBytes: size,
+	}, nil
+}
+
+func writeMetadata(tempPath string, finalPath string, meta Metadata) error {
+	data, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal backup metadata: %w", err)
+	}
+
+	file, err := os.OpenFile(tempPath, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("create backup metadata temp file: %w", err)
+	}
+
+	if _, err := file.Write(append(data, '\n')); err != nil {
+		file.Close()
+		return fmt.Errorf("write backup metadata: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close backup metadata temp file: %w", err)
+	}
+	if err := os.Rename(tempPath, finalPath); err != nil {
+		return fmt.Errorf("finalize backup metadata: %w", err)
+	}
+
+	return nil
+}
+
+func metadataPath(artifactPath string) string {
+	return artifactPath + metadataExtension
+}
+
+func parseArtifactTimestamp(name string) (time.Time, bool) {
+	if !strings.HasPrefix(name, artifactPrefix) || !strings.HasSuffix(name, artifactExtension) {
+		return time.Time{}, false
+	}
+
+	ts := strings.TrimSuffix(strings.TrimPrefix(name, artifactPrefix), artifactExtension)
+	parsed, err := time.Parse(timestampLayout, ts)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed.UTC(), true
+}
+
+func readMetadata(artifactPath string, metadataPath string) (Metadata, bool, error) {
+	stat, err := os.Stat(artifactPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Metadata{}, false, nil
+		}
+		return Metadata{}, false, fmt.Errorf("stat backup artifact: %w", err)
+	}
+
+	data, err := os.ReadFile(metadataPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Metadata{}, false, nil
+		}
+		return Metadata{}, false, fmt.Errorf("read backup metadata: %w", err)
+	}
+
+	var meta Metadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return Metadata{}, false, nil
+	}
+	if meta.FileName != filepath.Base(artifactPath) {
+		return Metadata{}, false, nil
+	}
+	if meta.SHA256 == "" || meta.SizeBytes <= 0 {
+		return Metadata{}, false, nil
+	}
+	if stat.Size() != meta.SizeBytes {
+		return Metadata{}, false, nil
+	}
+
+	return meta, true, nil
+}
+
+func removeIfExists(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove temp file %s: %w", path, err)
+	}
+	return nil
+}

--- a/internal/backup/manager_test.go
+++ b/internal/backup/manager_test.go
@@ -2,7 +2,9 @@ package backup
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -54,7 +56,7 @@ func TestRunBackup_CreatesVerifiableCompressedArtifactFromLiveDatabase(t *testin
 		t.Fatalf("runBackup() error = %v", err)
 	}
 
-	artifactPath := filepath.Join(backupDir, "backflow-20260425T123456Z.sqlite.gz")
+	artifactPath := filepath.Join(backupDir, "backlite-20260425T123456Z.sqlite.gz")
 	metadataPath := metadataPath(artifactPath)
 
 	if _, err := os.Stat(artifactPath); err != nil {
@@ -79,6 +81,15 @@ func TestRunBackup_CreatesVerifiableCompressedArtifactFromLiveDatabase(t *testin
 	}
 	if meta.SHA256 == "" {
 		t.Fatal("metadata sha256 is empty")
+	}
+	if meta.FinalizedAt.IsZero() {
+		t.Fatal("metadata finalized_at is zero, want non-zero finalization timestamp")
+	}
+	if meta.FinalizedAt.Before(meta.CreatedAt) {
+		t.Fatalf("metadata finalized_at = %v before created_at = %v", meta.FinalizedAt, meta.CreatedAt)
+	}
+	if err := verifyArtifactChecksum(artifactPath, meta.SHA256); err != nil {
+		t.Fatalf("verifyArtifactChecksum() error = %v", err)
 	}
 
 	verifyPath := filepath.Join(root, "verify.sqlite")
@@ -108,17 +119,12 @@ func TestNeedsBackup_IgnoresPartialArtifacts(t *testing.T) {
 	dir := t.TempDir()
 
 	oldTime := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
-	oldArtifact := filepath.Join(dir, "backflow-20260425T100000Z.sqlite.gz")
-	if err := writeTestArtifact(oldArtifact, Metadata{
-		FileName:  filepath.Base(oldArtifact),
-		CreatedAt: oldTime,
-		SHA256:    "abc123",
-		SizeBytes: int64(len("old-backup")),
-	}, []byte("old-backup")); err != nil {
-		t.Fatalf("writeTestArtifact(old) error = %v", err)
+	oldArtifact := filepath.Join(dir, "backlite-20260425T100000Z.sqlite.gz")
+	if err := writeValidTestArtifact(t, oldArtifact, oldTime, []byte("old-backup")); err != nil {
+		t.Fatalf("writeValidTestArtifact(old) error = %v", err)
 	}
 
-	partialArtifact := filepath.Join(dir, "backflow-20260425T115500Z.sqlite.gz")
+	partialArtifact := filepath.Join(dir, "backlite-20260425T115500Z.sqlite.gz")
 	if err := os.WriteFile(partialArtifact, []byte("partial"), 0o600); err != nil {
 		t.Fatalf("WriteFile(partialArtifact) error = %v", err)
 	}
@@ -147,6 +153,147 @@ func TestNeedsBackup_IgnoresPartialArtifacts(t *testing.T) {
 	}
 	if got := filepath.Base(latest.Path); got != filepath.Base(oldArtifact) {
 		t.Fatalf("latest artifact = %q, want %q", got, filepath.Base(oldArtifact))
+	}
+}
+
+func TestNeedsBackup_SkipsArtifactWithMismatchedSHA256(t *testing.T) {
+	dir := t.TempDir()
+
+	artifactPath := filepath.Join(dir, "backlite-20260425T100000Z.sqlite.gz")
+	if err := writeValidTestArtifact(t, artifactPath, time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC), []byte("original-bytes")); err != nil {
+		t.Fatalf("writeValidTestArtifact() error = %v", err)
+	}
+	// Corrupt the artifact in place without updating the sidecar. Same byte
+	// length, different content — exactly the case the structural-only
+	// check would let through.
+	if err := os.WriteFile(artifactPath, []byte("corrupted-byt!"), 0o600); err != nil {
+		t.Fatalf("corrupt WriteFile error = %v", err)
+	}
+
+	m := New(Config{
+		Enabled:   true,
+		Directory: dir,
+		Interval:  time.Hour,
+	})
+	m.now = func() time.Time {
+		return time.Date(2026, 4, 25, 11, 0, 0, 0, time.UTC)
+	}
+
+	due, latest, err := m.needsBackup()
+	if err != nil {
+		t.Fatalf("needsBackup() error = %v", err)
+	}
+	if !due {
+		t.Fatal("needsBackup() = false, want true when the only artifact's checksum does not match")
+	}
+	if latest != nil {
+		t.Fatalf("latest = %+v, want nil because the corrupted artifact must not be trusted", latest)
+	}
+}
+
+func TestNeedsBackup_FallsBackToOlderValidArtifactWhenNewerCorrupted(t *testing.T) {
+	dir := t.TempDir()
+
+	oldTime := time.Date(2026, 4, 25, 8, 0, 0, 0, time.UTC)
+	oldArtifact := filepath.Join(dir, "backlite-20260425T080000Z.sqlite.gz")
+	if err := writeValidTestArtifact(t, oldArtifact, oldTime, []byte("old-good")); err != nil {
+		t.Fatalf("writeValidTestArtifact(old) error = %v", err)
+	}
+
+	newTime := time.Date(2026, 4, 25, 11, 0, 0, 0, time.UTC)
+	newerArtifact := filepath.Join(dir, "backlite-20260425T110000Z.sqlite.gz")
+	if err := writeValidTestArtifact(t, newerArtifact, newTime, []byte("new-good")); err != nil {
+		t.Fatalf("writeValidTestArtifact(new) error = %v", err)
+	}
+	// Corrupt the newer artifact's bytes after writing the sidecar.
+	if err := os.WriteFile(newerArtifact, []byte("new-bad!"), 0o600); err != nil {
+		t.Fatalf("corrupt WriteFile error = %v", err)
+	}
+
+	m := New(Config{
+		Enabled:   true,
+		Directory: dir,
+		Interval:  time.Hour,
+	})
+	m.now = func() time.Time {
+		return time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	}
+
+	due, latest, err := m.needsBackup()
+	if err != nil {
+		t.Fatalf("needsBackup() error = %v", err)
+	}
+	if !due {
+		t.Fatal("needsBackup() = false, want true (older valid backup is 4 hours old, interval 1 hour)")
+	}
+	if latest == nil {
+		t.Fatal("latest = nil, want the older valid artifact")
+	}
+	if got := filepath.Base(latest.Path); got != filepath.Base(oldArtifact) {
+		t.Fatalf("latest = %q, want fallback to older valid artifact %q", got, filepath.Base(oldArtifact))
+	}
+}
+
+func TestNeedsBackup_NotDueWhenLatestArtifactIsFresh(t *testing.T) {
+	dir := t.TempDir()
+
+	finalized := time.Date(2026, 4, 25, 11, 30, 0, 0, time.UTC)
+	artifactPath := filepath.Join(dir, "backlite-20260425T112800Z.sqlite.gz")
+	if err := writeValidTestArtifactFinalizedAt(t, artifactPath, finalized.Add(-2*time.Minute), finalized, []byte("fresh-backup")); err != nil {
+		t.Fatalf("writeValidTestArtifactFinalizedAt() error = %v", err)
+	}
+
+	m := New(Config{
+		Enabled:   true,
+		Directory: dir,
+		Interval:  time.Hour,
+	})
+	m.now = func() time.Time {
+		return time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	}
+
+	due, latest, err := m.needsBackup()
+	if err != nil {
+		t.Fatalf("needsBackup() error = %v", err)
+	}
+	if due {
+		t.Fatal("needsBackup() = true, want false (latest backup finalized 30 minutes ago, interval 1 hour)")
+	}
+	if latest == nil {
+		t.Fatal("latest = nil, want the fresh artifact")
+	}
+}
+
+func TestNeedsBackup_UsesFinalizedAtForAgeComparison(t *testing.T) {
+	// Locks in the fix for the age-comparison bug: the filename / scheduled
+	// timestamp can be hours older than `now` while the backup is still fresh
+	// because finalization just completed. Without `FinalizedAt`-based aging,
+	// a backup that takes longer than the interval would immediately appear
+	// stale and the scheduler would loop continuously.
+	dir := t.TempDir()
+
+	scheduled := time.Date(2026, 4, 25, 9, 0, 0, 0, time.UTC)
+	finalized := time.Date(2026, 4, 25, 11, 45, 0, 0, time.UTC)
+	artifactPath := filepath.Join(dir, "backlite-20260425T090000Z.sqlite.gz")
+	if err := writeValidTestArtifactFinalizedAt(t, artifactPath, scheduled, finalized, []byte("slow-backup")); err != nil {
+		t.Fatalf("writeValidTestArtifactFinalizedAt() error = %v", err)
+	}
+
+	m := New(Config{
+		Enabled:   true,
+		Directory: dir,
+		Interval:  time.Hour,
+	})
+	m.now = func() time.Time {
+		return time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	}
+
+	due, _, err := m.needsBackup()
+	if err != nil {
+		t.Fatalf("needsBackup() error = %v", err)
+	}
+	if due {
+		t.Fatal("needsBackup() = true, want false (finalized 15 minutes ago, even though scheduled 3 hours ago)")
 	}
 }
 
@@ -184,9 +331,23 @@ func TestMaybeSchedule_RunsSingleWorkerAtATime(t *testing.T) {
 	waitFor(t, 2*time.Second, func() bool { return !m.isRunning() })
 }
 
-func writeTestArtifact(path string, meta Metadata, contents []byte) error {
+func writeValidTestArtifact(t *testing.T, path string, createdAt time.Time, contents []byte) error {
+	t.Helper()
+	return writeValidTestArtifactFinalizedAt(t, path, createdAt, createdAt, contents)
+}
+
+func writeValidTestArtifactFinalizedAt(t *testing.T, path string, createdAt time.Time, finalizedAt time.Time, contents []byte) error {
+	t.Helper()
 	if err := os.WriteFile(path, contents, 0o600); err != nil {
 		return err
+	}
+	sum := sha256.Sum256(contents)
+	meta := Metadata{
+		FileName:    filepath.Base(path),
+		CreatedAt:   createdAt,
+		FinalizedAt: finalizedAt,
+		SHA256:      hex.EncodeToString(sum[:]),
+		SizeBytes:   int64(len(contents)),
 	}
 	data, err := json.Marshal(meta)
 	if err != nil {

--- a/internal/backup/manager_test.go
+++ b/internal/backup/manager_test.go
@@ -1,0 +1,210 @@
+package backup
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/brian-bell/backlite/internal/models"
+	"github.com/brian-bell/backlite/internal/store"
+)
+
+func TestRunBackup_CreatesVerifiableCompressedArtifactFromLiveDatabase(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "backlite.db")
+	backupDir := filepath.Join(root, "backups")
+
+	s, err := store.NewSQLite(ctx, dbPath, filepath.Join("..", "..", "migrations"))
+	if err != nil {
+		t.Fatalf("NewSQLite() error = %v", err)
+	}
+	defer s.Close()
+
+	now := time.Date(2026, 4, 25, 12, 34, 56, 0, time.UTC)
+	task := &models.Task{
+		ID:        "bf_backup_test",
+		Status:    models.TaskStatusPending,
+		TaskMode:  models.TaskModeCode,
+		Harness:   models.HarnessClaudeCode,
+		RepoURL:   "https://github.com/test/repo",
+		Branch:    "backlite/test",
+		Prompt:    "exercise backup worker",
+		Model:     "claude-sonnet-4-6",
+		CreatePR:  true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+
+	m := New(Config{
+		Enabled:      true,
+		DatabasePath: dbPath,
+		Directory:    backupDir,
+		Interval:     24 * time.Hour,
+	})
+
+	if err := m.runBackup(ctx, now); err != nil {
+		t.Fatalf("runBackup() error = %v", err)
+	}
+
+	artifactPath := filepath.Join(backupDir, "backflow-20260425T123456Z.sqlite.gz")
+	metadataPath := metadataPath(artifactPath)
+
+	if _, err := os.Stat(artifactPath); err != nil {
+		t.Fatalf("artifact missing: %v", err)
+	}
+	if _, err := os.Stat(metadataPath); err != nil {
+		t.Fatalf("metadata missing: %v", err)
+	}
+
+	meta, valid, err := readMetadata(artifactPath, metadataPath)
+	if err != nil {
+		t.Fatalf("readMetadata() error = %v", err)
+	}
+	if !valid {
+		t.Fatal("readMetadata() reported artifact invalid, want valid finalized backup")
+	}
+	if meta.FileName != filepath.Base(artifactPath) {
+		t.Fatalf("metadata file_name = %q, want %q", meta.FileName, filepath.Base(artifactPath))
+	}
+	if meta.SizeBytes <= 0 {
+		t.Fatalf("metadata size_bytes = %d, want > 0", meta.SizeBytes)
+	}
+	if meta.SHA256 == "" {
+		t.Fatal("metadata sha256 is empty")
+	}
+
+	verifyPath := filepath.Join(root, "verify.sqlite")
+	if err := decompressFile(artifactPath, verifyPath); err != nil {
+		t.Fatalf("decompressFile() error = %v", err)
+	}
+	if err := validateSQLiteDatabase(ctx, verifyPath); err != nil {
+		t.Fatalf("validateSQLiteDatabase() error = %v", err)
+	}
+
+	db, err := sql.Open("sqlite", verifyPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	defer db.Close()
+
+	var count int
+	if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM tasks").Scan(&count); err != nil {
+		t.Fatalf("query backup task count: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("backup task count = %d, want 1", count)
+	}
+}
+
+func TestNeedsBackup_IgnoresPartialArtifacts(t *testing.T) {
+	dir := t.TempDir()
+
+	oldTime := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
+	oldArtifact := filepath.Join(dir, "backflow-20260425T100000Z.sqlite.gz")
+	if err := writeTestArtifact(oldArtifact, Metadata{
+		FileName:  filepath.Base(oldArtifact),
+		CreatedAt: oldTime,
+		SHA256:    "abc123",
+		SizeBytes: int64(len("old-backup")),
+	}, []byte("old-backup")); err != nil {
+		t.Fatalf("writeTestArtifact(old) error = %v", err)
+	}
+
+	partialArtifact := filepath.Join(dir, "backflow-20260425T115500Z.sqlite.gz")
+	if err := os.WriteFile(partialArtifact, []byte("partial"), 0o600); err != nil {
+		t.Fatalf("WriteFile(partialArtifact) error = %v", err)
+	}
+	if err := os.WriteFile(partialArtifact+".tmp", []byte("partial"), 0o600); err != nil {
+		t.Fatalf("WriteFile(temp partial) error = %v", err)
+	}
+
+	m := New(Config{
+		Enabled:   true,
+		Directory: dir,
+		Interval:  time.Hour,
+	})
+	m.now = func() time.Time {
+		return time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	}
+
+	due, latest, err := m.needsBackup()
+	if err != nil {
+		t.Fatalf("needsBackup() error = %v", err)
+	}
+	if !due {
+		t.Fatal("needsBackup() = false, want true because only finalized backup is two hours old")
+	}
+	if latest == nil {
+		t.Fatal("latest artifact = nil, want oldest finalized backup")
+	}
+	if got := filepath.Base(latest.Path); got != filepath.Base(oldArtifact) {
+		t.Fatalf("latest artifact = %q, want %q", got, filepath.Base(oldArtifact))
+	}
+}
+
+func TestMaybeSchedule_RunsSingleWorkerAtATime(t *testing.T) {
+	m := New(Config{
+		Enabled:   true,
+		Directory: t.TempDir(),
+		Interval:  time.Hour,
+	})
+
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	m.runBackupFn = func(context.Context, time.Time) error {
+		started <- struct{}{}
+		<-release
+		return nil
+	}
+
+	m.MaybeSchedule(context.Background())
+	m.MaybeSchedule(context.Background())
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for backup worker to start")
+	}
+
+	select {
+	case <-started:
+		t.Fatal("second backup worker started while first was still running")
+	default:
+	}
+
+	close(release)
+	waitFor(t, 2*time.Second, func() bool { return !m.isRunning() })
+}
+
+func writeTestArtifact(path string, meta Metadata, contents []byte) error {
+	if err := os.WriteFile(path, contents, 0o600); err != nil {
+		return err
+	}
+	data, err := json.Marshal(meta)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(metadataPath(path), data, 0o600)
+}
+
+func waitFor(t *testing.T, timeout time.Duration, condition func() bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatal("condition was not met before timeout")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -73,6 +74,11 @@ type Config struct {
 	// Database
 	DatabasePath string
 
+	// Local SQLite backups
+	LocalBackupEnabled  bool
+	LocalBackupDir      string
+	LocalBackupInterval time.Duration
+
 	// Retry
 	MaxUserRetries int
 
@@ -117,6 +123,8 @@ func Load() (*Config, error) {
 		WebhookURL:            os.Getenv("BACKFLOW_WEBHOOK_URL"),
 		LogFile:               os.Getenv("BACKFLOW_LOG_FILE"),
 		DatabasePath:          envOr("BACKFLOW_DATABASE_PATH", "./backlite.db"),
+		LocalBackupDir:        envOr("BACKFLOW_LOCAL_BACKUP_DIR", defaultLocalBackupDir()),
+		LocalBackupInterval:   time.Duration(envInt("BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC", 86400)) * time.Second,
 		MaxUserRetries:        envInt("BACKFLOW_MAX_USER_RETRIES", 2),
 		PollInterval:          time.Duration(envInt("BACKFLOW_POLL_INTERVAL_SEC", 5)) * time.Second,
 	}
@@ -124,8 +132,10 @@ func Load() (*Config, error) {
 	c.DefaultCreatePR = envBool("BACKFLOW_DEFAULT_CREATE_PR", true)
 	c.DefaultSelfReview = envBool("BACKFLOW_DEFAULT_SELF_REVIEW", false)
 	c.DefaultSaveOutput = envBool("BACKFLOW_DEFAULT_SAVE_AGENT_OUTPUT", true)
+	c.LocalBackupEnabled = envBool("BACKFLOW_LOCAL_BACKUP_ENABLED", true)
 
 	c.WebhookEvents = envCSV("BACKFLOW_WEBHOOK_EVENTS")
+	c.LocalBackupDir = expandHomeDir(c.LocalBackupDir)
 
 	if c.AnthropicAPIKey == "" {
 		return nil, fmt.Errorf("ANTHROPIC_API_KEY is required")
@@ -137,6 +147,14 @@ func Load() (*Config, error) {
 
 	if c.DatabasePath == "" {
 		return nil, fmt.Errorf("BACKFLOW_DATABASE_PATH is required")
+	}
+	if c.LocalBackupEnabled {
+		if c.LocalBackupDir == "" {
+			return nil, fmt.Errorf("BACKFLOW_LOCAL_BACKUP_DIR is required when local backups are enabled")
+		}
+		if c.LocalBackupInterval <= 0 {
+			return nil, fmt.Errorf("BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC must be > 0 when local backups are enabled")
+		}
 	}
 
 	if c.ContainerCPUs < 1 {
@@ -229,4 +247,32 @@ func envCSV(key string) []string {
 		}
 	}
 	return values
+}
+
+func defaultLocalBackupDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return "./backlite-backups"
+	}
+	return filepath.Join(home, "backlite-backups")
+}
+
+func expandHomeDir(path string) string {
+	if path == "" {
+		return path
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return path
+	}
+
+	switch {
+	case path == "~":
+		return home
+	case strings.HasPrefix(path, "~/"), strings.HasPrefix(path, "~\\"):
+		return filepath.Join(home, path[2:])
+	default:
+		return path
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -101,6 +102,75 @@ func TestLoad_LogFile_Set(t *testing.T) {
 	}
 	if cfg.LogFile != "/tmp/backlite.log" {
 		t.Errorf("LogFile = %q, want %q", cfg.LogFile, "/tmp/backlite.log")
+	}
+}
+
+func TestLoad_LocalBackupDefaults(t *testing.T) {
+	setBaseEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	if !cfg.LocalBackupEnabled {
+		t.Fatal("LocalBackupEnabled = false, want true by default")
+	}
+	if cfg.LocalBackupDir != filepath.Join(home, "backlite-backups") {
+		t.Fatalf("LocalBackupDir = %q, want %q", cfg.LocalBackupDir, filepath.Join(home, "backlite-backups"))
+	}
+	if cfg.LocalBackupInterval != 24*time.Hour {
+		t.Fatalf("LocalBackupInterval = %v, want %v", cfg.LocalBackupInterval, 24*time.Hour)
+	}
+}
+
+func TestLoad_LocalBackupOverrides(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("BACKFLOW_LOCAL_BACKUP_DIR", "~/custom-backups")
+	t.Setenv("BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC", "7200")
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+
+	if cfg.LocalBackupDir != filepath.Join(home, "custom-backups") {
+		t.Fatalf("LocalBackupDir = %q, want %q", cfg.LocalBackupDir, filepath.Join(home, "custom-backups"))
+	}
+	if cfg.LocalBackupInterval != 2*time.Hour {
+		t.Fatalf("LocalBackupInterval = %v, want %v", cfg.LocalBackupInterval, 2*time.Hour)
+	}
+}
+
+func TestLoad_LocalBackupCanBeDisabled(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("BACKFLOW_LOCAL_BACKUP_ENABLED", "false")
+	t.Setenv("BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC", "0")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+	if cfg.LocalBackupEnabled {
+		t.Fatal("LocalBackupEnabled = true, want false")
+	}
+}
+
+func TestLoad_LocalBackupRequiresPositiveIntervalWhenEnabled(t *testing.T) {
+	setBaseEnv(t)
+	t.Setenv("BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC", "0")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error for zero local backup interval")
+	}
+	if !strings.Contains(err.Error(), "BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC") {
+		t.Fatalf("error = %v, want interval env name", err)
 	}
 }
 

--- a/internal/orchestrator/helpers_test.go
+++ b/internal/orchestrator/helpers_test.go
@@ -391,6 +391,23 @@ func (m *mockWriter) SaveMetadata(_ context.Context, taskID string, metadata any
 	return nil
 }
 
+type mockBackupScheduler struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (m *mockBackupScheduler) MaybeSchedule(context.Context) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+}
+
+func (m *mockBackupScheduler) Calls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
+
 // newTestBus creates an EventBus with a mockNotifier subscribed.
 // Call bus.Close() before reading events from the notifier.
 func newTestBus() (*notify.EventBus, *mockNotifier) {
@@ -413,6 +430,7 @@ func newTestOrchestrator(s store.Store, bus *notify.EventBus, opts ...func(*Orch
 		config:          cfg,
 		bus:             bus,
 		docker:          &mockDockerManager{},
+		backups:         nil,
 		stopCh:          make(chan struct{}),
 		inspectFailures: make(map[string]int),
 	}
@@ -436,6 +454,10 @@ func withOutputs(w Writer) func(*Orchestrator) {
 
 func withEmbedder(e embeddings.Embedder) func(*Orchestrator) {
 	return func(o *Orchestrator) { o.embedder = e }
+}
+
+func withBackups(b backupScheduler) func(*Orchestrator) {
+	return func(o *Orchestrator) { o.backups = b }
 }
 
 // mockEmbedder records Embed calls and returns a fixed vector or injected error.

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	"github.com/brian-bell/backlite/internal/backup"
 	"github.com/brian-bell/backlite/internal/config"
 	"github.com/brian-bell/backlite/internal/embeddings"
 	"github.com/brian-bell/backlite/internal/models"
@@ -51,6 +52,7 @@ type Orchestrator struct {
 	outputs   Writer
 	embedder  embeddings.Embedder
 	lifecycle *lifecycle.Coordinator
+	backups   backupScheduler
 
 	mu              sync.Mutex
 	running         int
@@ -58,14 +60,24 @@ type Orchestrator struct {
 	inspectFailures map[string]int // task ID -> consecutive inspect failure count
 }
 
+type backupScheduler interface {
+	MaybeSchedule(context.Context)
+}
+
 func New(s store.Store, cfg *config.Config, bus *notify.EventBus, runner Runner, outputs Writer, embedder embeddings.Embedder) *Orchestrator {
 	o := &Orchestrator{
-		store:           s,
-		config:          cfg,
-		bus:             bus,
-		docker:          runner,
-		outputs:         outputs,
-		embedder:        embedder,
+		store:    s,
+		config:   cfg,
+		bus:      bus,
+		docker:   runner,
+		outputs:  outputs,
+		embedder: embedder,
+		backups: backup.New(backup.Config{
+			Enabled:      cfg.LocalBackupEnabled,
+			DatabasePath: cfg.DatabasePath,
+			Directory:    cfg.LocalBackupDir,
+			Interval:     cfg.LocalBackupInterval,
+		}),
 		stopCh:          make(chan struct{}),
 		inspectFailures: make(map[string]int),
 	}
@@ -146,6 +158,9 @@ func (o *Orchestrator) tick(ctx context.Context) {
 	o.monitorRecovering(ctx)
 	o.monitorRunning(ctx)
 	o.dispatchPending(ctx)
+	if o.backups != nil {
+		o.backups.MaybeSchedule(ctx)
+	}
 }
 
 // --- Shared helpers used across dispatch, monitor, and recovery ---

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -25,3 +25,18 @@ func TestRunning_ReflectsIncrementAndDecrement(t *testing.T) {
 		t.Fatalf("Running() = %d, want 1", got)
 	}
 }
+
+func TestTick_SchedulesLocalBackups(t *testing.T) {
+	ms := newMockStore()
+	bus, _ := newTestBus()
+	defer bus.Close()
+
+	scheduler := &mockBackupScheduler{}
+	o := newTestOrchestrator(ms, bus, withBackups(scheduler))
+
+	o.tick(t.Context())
+
+	if got := scheduler.Calls(); got != 1 {
+		t.Fatalf("MaybeSchedule() calls = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a server-managed local SQLite backup manager that uses the SQLite online backup API, gzip compression, integrity verification, and checksum/size sidecar metadata
- wire local backup scheduling into the orchestrator loop with config/env support for enablement, directory, and interval
- add tests for config defaults/overrides, single-worker scheduling, partial artifact age detection, and restoring a compressed backup from a live database

## Why
Implements issue #27 by giving Backlite an end-to-end local backup path that runs in the background without blocking task orchestration and only considers finalized artifacts when deciding whether a fresh backup is needed.

## Validation
- go test -tags nocontainers ./... -count=1
- go vet ./...
