### PR TITLE
Slice 1 (#60): Email summary delivery — tracer-bullet end-to-end

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,14 @@ BACKFLOW_DATABASE_PATH=./backlite.db
 # Unset to roll back instantly. See CLAUDE.md "Skill-based agent image" for details.
 # BACKFLOW_SKILL_AGENT_IMAGE=backlite-skill-agent
 
+# Email summary delivery (Resend) — opt-in for read-mode tasks on the skill-agent image.
+# All three vars must be set together (or all unset); partial config blocks startup.
+# BACKFLOW_NOTIFY_EMAIL_FROM must use a Resend-verified sender domain (SPF + DKIM CNAMEs
+# published in DNS). The Resend sandbox sender is not supported. See docs/resend-setup.md.
+# BACKFLOW_RESEND_API_KEY=re_...
+# BACKFLOW_NOTIFY_EMAIL_FROM=backflow@mail.example.com
+# BACKFLOW_NOTIFY_EMAIL_TO=you@example.com
+
 # Concurrency (cap is <= 6; see internal/config/config.go)
 BACKFLOW_MAX_CONTAINERS=1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,7 @@ Create new migrations in `migrations/` with the next numeric prefix, `-- +goose 
 Additional docs in `docs/`:
 - `schema.md` — Database schema (tables, columns, indexes, status lifecycles)
 - `self-hosting.md` — Single-host deployment walkthrough
+- `resend-setup.md` — Operator setup for the read skill's email summary delivery (Resend account, sender-domain DNS, env vars)
 - `adrs/` — Architecture Decision Records (historical; see individual files for current status)
 
 The OpenAPI 3.0 spec lives at `api/openapi.yaml`. `make test-schema` runs Schemathesis fuzz tests against it.

--- a/docker/skill-agent/skills/read/SKILL.md
+++ b/docker/skill-agent/skills/read/SKILL.md
@@ -84,6 +84,12 @@ best-effort hint mid-run.
    matching the same JSON. Both writes are required: the marker is for live
    log streaming, the file is for the orchestrator's post-exit read.
 
+8. **Send email summary.** After `status.json` is written, invoke
+   `~/.claude/skills/read/send-email.sh`. The script reads
+   `$HOME/workspace/status.json`, formats a plain-text summary, and POSTs
+   it to Resend. It is a no-op (`exit 0` with a log line) when
+   `RESEND_API_KEY` is unset, so it's safe to invoke unconditionally.
+
 ## status.json schema (read mode)
 
 ```json

--- a/docker/skill-agent/skills/read/send-email.sh
+++ b/docker/skill-agent/skills/read/send-email.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# send-email.sh — send a plain-text email summary of a read-mode reading
+# via Resend.
+#
+# Usage: send-email.sh [status.json path]
+#   status.json path defaults to $HOME/workspace/status.json.
+#
+# No-op (exit 0 with a log line) when RESEND_API_KEY, NOTIFY_EMAIL_FROM, or
+# NOTIFY_EMAIL_TO is unset, or when the status.json file is missing. Email
+# delivery failures are logged and exit 0 as well — email is advisory and
+# must not block task completion.
+
+STATUS_JSON="${1:-${HOME}/workspace/status.json}"
+
+if [ -z "${RESEND_API_KEY:-}" ]; then
+    echo "send-email: RESEND_API_KEY not set; skipping email send" >&2
+    exit 0
+fi
+if [ -z "${NOTIFY_EMAIL_FROM:-}" ] || [ -z "${NOTIFY_EMAIL_TO:-}" ]; then
+    echo "send-email: NOTIFY_EMAIL_FROM or NOTIFY_EMAIL_TO not set; skipping email send" >&2
+    exit 0
+fi
+if [ ! -f "$STATUS_JSON" ]; then
+    echo "send-email: status file $STATUS_JSON not found; skipping email send" >&2
+    exit 0
+fi
+
+URL=$(jq -r '.url // ""' "$STATUS_JSON")
+TITLE=$(jq -r '.title // ""' "$STATUS_JSON")
+TLDR=$(jq -r '.tldr // ""' "$STATUS_JSON")
+TASK_ID_VAL="${TASK_ID:-}"
+
+BODY=$(printf 'URL: %s\nTitle: %s\nTL;DR: %s\n\nTask: %s\n' \
+    "$URL" "$TITLE" "$TLDR" "$TASK_ID_VAL")
+
+PAYLOAD=$(jq -n \
+    --arg from "$NOTIFY_EMAIL_FROM" \
+    --arg to "$NOTIFY_EMAIL_TO" \
+    --arg subject "$TITLE" \
+    --arg text "$BODY" \
+    '{from: $from, to: [$to], subject: $subject, text: $text}')
+
+BASE_URL="${RESEND_BASE_URL:-https://api.resend.com}"
+
+if ! curl -fsS \
+    -H "Authorization: Bearer ${RESEND_API_KEY}" \
+    -H "Content-Type: application/json" \
+    -d "$PAYLOAD" \
+    "${BASE_URL}/emails" >/dev/null; then
+    echo "send-email: Resend API request failed; continuing" >&2
+    exit 0
+fi
+
+echo "send-email: sent email summary for task ${TASK_ID_VAL}" >&2

--- a/docker/skill-agent/test_entrypoint.sh
+++ b/docker/skill-agent/test_entrypoint.sh
@@ -366,5 +366,180 @@ EOF
 )
 pass "installs read skill with helper scripts (read-embed.sh, read-similar.sh, read-lookup.sh)"
 
+# --- send-email.sh: happy-path POST shape against fake Resend server ---
+(
+    tmp=$(mktemp -d)
+    capture="$tmp/captured-request"
+    pid_file="$tmp/server.pid"
+    port_file="$tmp/port"
+    trap '[ -f "$pid_file" ] && kill "$(cat "$pid_file")" 2>/dev/null || true; rm -rf "$tmp"' EXIT
+
+    python3 - "$capture" "$port_file" "$pid_file" >/dev/null 2>&1 <<'PYEOF' &
+import json, sys, os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+capture = sys.argv[1]
+port_file = sys.argv[2]
+pid_file = sys.argv[3]
+
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length).decode("utf-8")
+        with open(capture, "w") as f:
+            json.dump({
+                "method": self.command,
+                "path": self.path,
+                "headers": dict(self.headers),
+                "body": body,
+            }, f)
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"id":"fake"}')
+    def log_message(self, *a, **kw):
+        pass
+
+srv = HTTPServer(("127.0.0.1", 0), H)
+with open(port_file, "w") as f:
+    f.write(str(srv.server_address[1]))
+with open(pid_file, "w") as f:
+    f.write(str(os.getpid()))
+srv.serve_forever()
+PYEOF
+
+    # Wait for server to bind a port (cap at ~3s)
+    for _ in $(seq 1 30); do
+        if [ -s "$port_file" ]; then break; fi
+        sleep 0.1
+    done
+    if [ ! -s "$port_file" ]; then
+        fail "send-email happy path: fake Resend server did not start"
+    fi
+    PORT=$(cat "$port_file")
+
+    # Stub status.json with a populated reading.
+    cat >"$tmp/status.json" <<'JSON'
+{
+  "url": "https://example.com/post",
+  "title": "Example Post Title",
+  "tldr": "A pithy one-line summary of the post."
+}
+JSON
+
+    export RESEND_API_KEY="re_test"
+    export NOTIFY_EMAIL_FROM="from@example.com"
+    export NOTIFY_EMAIL_TO="to@example.com"
+    export RESEND_BASE_URL="http://127.0.0.1:$PORT"
+    export TASK_ID="bf_emailtest"
+
+    SCRIPT="$DIR/skills/read/send-email.sh"
+    if ! "$SCRIPT" "$tmp/status.json" >/dev/null 2>&1; then
+        fail "send-email happy path: script exited non-zero"
+    fi
+
+    if [ ! -s "$capture" ]; then
+        fail "send-email happy path: fake server did not record any request"
+    fi
+    method=$(jq -r '.method' "$capture")
+    if [ "$method" != "POST" ]; then
+        fail "send-email happy path: expected POST, got $method"
+    fi
+    path=$(jq -r '.path' "$capture")
+    if [ "$path" != "/emails" ]; then
+        fail "send-email happy path: expected path /emails, got $path"
+    fi
+    auth=$(jq -r '.headers.Authorization' "$capture")
+    if [ "$auth" != "Bearer re_test" ]; then
+        fail "send-email happy path: expected Authorization 'Bearer re_test', got $auth"
+    fi
+    ctype=$(jq -r '.headers["Content-Type"]' "$capture")
+    if [ "$ctype" != "application/json" ]; then
+        fail "send-email happy path: expected Content-Type application/json, got $ctype"
+    fi
+    body_from=$(jq -r '.body | fromjson | .from' "$capture")
+    if [ "$body_from" != "from@example.com" ]; then
+        fail "send-email happy path: expected body.from from@example.com, got $body_from"
+    fi
+    body_to=$(jq -r '.body | fromjson | .to[0]' "$capture")
+    if [ "$body_to" != "to@example.com" ]; then
+        fail "send-email happy path: expected body.to[0] to@example.com, got $body_to"
+    fi
+    body_subject=$(jq -r '.body | fromjson | .subject' "$capture")
+    if [ "$body_subject" != "Example Post Title" ]; then
+        fail "send-email happy path: expected body.subject 'Example Post Title', got $body_subject"
+    fi
+    body_text=$(jq -r '.body | fromjson | .text' "$capture")
+    for needle in "https://example.com/post" "Example Post Title" "A pithy one-line summary" "Task: bf_emailtest"; do
+        if [[ "$body_text" != *"$needle"* ]]; then
+            fail "send-email happy path: body.text missing '$needle', got: $body_text"
+        fi
+    done
+)
+pass "send-email.sh POSTs to /emails with Bearer auth and JSON body containing from/to/subject/text"
+
+# --- send-email.sh: no-op when RESEND_API_KEY is unset ---
+(
+    tmp=$(mktemp -d)
+    capture="$tmp/captured-request"
+    pid_file="$tmp/server.pid"
+    port_file="$tmp/port"
+    trap '[ -f "$pid_file" ] && kill "$(cat "$pid_file")" 2>/dev/null || true; rm -rf "$tmp"' EXIT
+
+    python3 - "$capture" "$port_file" "$pid_file" >/dev/null 2>&1 <<'PYEOF' &
+import json, sys, os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+capture = sys.argv[1]
+port_file = sys.argv[2]
+pid_file = sys.argv[3]
+
+class H(BaseHTTPRequestHandler):
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", "0"))
+        self.rfile.read(length)
+        with open(capture, "w") as f:
+            f.write("posted")
+        self.send_response(200); self.end_headers()
+    def log_message(self, *a, **kw):
+        pass
+
+srv = HTTPServer(("127.0.0.1", 0), H)
+with open(port_file, "w") as f:
+    f.write(str(srv.server_address[1]))
+with open(pid_file, "w") as f:
+    f.write(str(os.getpid()))
+srv.serve_forever()
+PYEOF
+
+    for _ in $(seq 1 30); do
+        if [ -s "$port_file" ]; then break; fi
+        sleep 0.1
+    done
+    if [ ! -s "$port_file" ]; then
+        fail "send-email no-op: fake Resend server did not start"
+    fi
+    PORT=$(cat "$port_file")
+
+    cat >"$tmp/status.json" <<'JSON'
+{"url":"https://example.com","title":"x","tldr":"y"}
+JSON
+
+    unset RESEND_API_KEY
+    export NOTIFY_EMAIL_FROM="from@example.com"
+    export NOTIFY_EMAIL_TO="to@example.com"
+    export RESEND_BASE_URL="http://127.0.0.1:$PORT"
+    export TASK_ID="bf_noop"
+
+    SCRIPT="$DIR/skills/read/send-email.sh"
+    if ! "$SCRIPT" "$tmp/status.json" >/dev/null 2>&1; then
+        fail "send-email no-op: script should exit 0 when RESEND_API_KEY is unset"
+    fi
+    if [ -s "$capture" ]; then
+        fail "send-email no-op: script must not POST when RESEND_API_KEY is unset (capture: $(cat "$capture"))"
+    fi
+)
+pass "send-email.sh exits 0 without POSTing when RESEND_API_KEY is unset"
+
 echo
 echo "All skill-agent entrypoint tests passed."

--- a/docs/resend-setup.md
+++ b/docs/resend-setup.md
@@ -1,0 +1,95 @@
+# Resend setup for email summary delivery
+
+When configured, the read skill emails a plain-text summary of each completed
+read-mode task to a fixed inbox. The skill bundle owns the sending; the
+orchestrator's job is just to propagate three env vars into the skill-agent
+container.
+
+This guide walks through the operator-side prerequisites. None of it is
+optional — Resend rejects sends from unverified domains, and Backflow's
+startup gate blocks partial configurations.
+
+## Scope
+
+- Read mode only (`task_mode: "read"`).
+- `claude_code` harness only.
+- Skill-agent image only (`BACKFLOW_SKILL_AGENT_IMAGE` set).
+
+Codex read tasks (which route to `docker/reader/`) and non-read modes do not
+send email in this slice. Container-level failures where the skill never
+runs (image pull failure, OOM kill, timeout) also do not send email — use
+the existing webhook + DB for those signals.
+
+## 1. Create a Resend account and API key
+
+1. Sign up at <https://resend.com>.
+2. In the dashboard, create an API key with "Sending access".
+3. Copy the key (it begins with `re_`). This is the value of
+   `BACKFLOW_RESEND_API_KEY`.
+
+## 2. Verify a sender domain
+
+The `From` address must use a domain you own and have verified with Resend.
+The Resend sandbox sender (`onboarding@resend.dev`) is **not** supported —
+Resend will reject the send and the email will silently fail (the read task
+itself still completes).
+
+1. In the Resend dashboard, go to **Domains → Add Domain** and enter the
+   domain you want to send from (e.g., `mail.example.com`).
+2. Resend shows you a set of DNS records to publish — typically:
+   - one SPF `TXT` record,
+   - two or three DKIM `CNAME` records,
+   - optionally a return-path `CNAME` for bounce tracking.
+3. Add those records at your DNS provider. Wait for Resend to mark the
+   domain as **Verified** (usually a few minutes; can be longer depending on
+   your DNS TTLs).
+
+The address you set as `BACKFLOW_NOTIFY_EMAIL_FROM` (e.g.,
+`backflow@mail.example.com`) must use this verified domain. The local part
+(before the `@`) is yours to choose.
+
+## 3. Pick a recipient
+
+`BACKFLOW_NOTIFY_EMAIL_TO` is just an inbox you control. No DNS work is
+required for the recipient.
+
+## 4. Set the env vars
+
+The three vars are read at startup. See `internal/config/config.go` for the
+authoritative list and any current defaults.
+
+- `BACKFLOW_RESEND_API_KEY` — the `re_…` key from step 1.
+- `BACKFLOW_NOTIFY_EMAIL_FROM` — `Name <local@verified-domain>` or just
+  `local@verified-domain`. Must contain `@`.
+- `BACKFLOW_NOTIFY_EMAIL_TO` — recipient address. Must contain `@`.
+
+All three must be set together. If you set one or two but not all three,
+`config.Load()` fails at startup with a named-var error, so you find the
+typo before you wonder why no email arrived.
+
+Inside the skill-agent container these vars are available without the
+`BACKFLOW_` prefix (matching how `OPENAI_API_KEY` is propagated):
+`RESEND_API_KEY`, `NOTIFY_EMAIL_FROM`, `NOTIFY_EMAIL_TO`. They are reserved
+names — per-task `env_vars` cannot override them.
+
+## 5. Verify delivery
+
+1. Submit a read task:
+   ```bash
+   curl -X POST localhost:8080/api/v1/tasks \
+       -H "Authorization: Bearer $BACKFLOW_API_KEY" \
+       -H "Content-Type: application/json" \
+       -d '{"task_mode":"read","prompt":"https://example.com","harness":"claude_code"}'
+   ```
+2. Wait for the `task.completed` webhook (or poll `GET /api/v1/tasks/{id}`).
+3. Check the `BACKFLOW_NOTIFY_EMAIL_TO` inbox — you should see an email
+   whose subject is the page title and whose body contains the URL, title,
+   TL;DR, and a `Task: bf_…` line.
+
+If the email is missing:
+
+- Check the orchestrator logs for the skill-agent container's stderr — the
+  script logs `send-email: …` lines on both success and failure.
+- Confirm the sender domain is **Verified** (not "Pending") in the Resend
+  dashboard.
+- Check Resend's **Logs** view for rejected sends.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	AnthropicAPIKey string
 	OpenAIAPIKey    string
 
+	// Email notification (Resend). All-or-nothing — see Load() gating.
+	ResendAPIKey    string
+	NotifyEmailFrom string
+	NotifyEmailTo   string
+
 	// Capacity
 	MaxContainers int
 
@@ -83,6 +88,9 @@ func Load() (*Config, error) {
 		APIKey:                os.Getenv("BACKFLOW_API_KEY"),
 		AnthropicAPIKey:       os.Getenv("ANTHROPIC_API_KEY"),
 		OpenAIAPIKey:          os.Getenv("OPENAI_API_KEY"),
+		ResendAPIKey:          os.Getenv("BACKFLOW_RESEND_API_KEY"),
+		NotifyEmailFrom:       os.Getenv("BACKFLOW_NOTIFY_EMAIL_FROM"),
+		NotifyEmailTo:         os.Getenv("BACKFLOW_NOTIFY_EMAIL_TO"),
 		MaxContainers:         envInt("BACKFLOW_MAX_CONTAINERS", 1),
 		ContainerCPUs:         envInt("BACKFLOW_CONTAINER_CPUS", 2),
 		ContainerMemGB:        envInt("BACKFLOW_CONTAINER_MEMORY_GB", 8),
@@ -142,6 +150,21 @@ func Load() (*Config, error) {
 			return nil, fmt.Errorf("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC must be > 0 when BACKFLOW_READER_IMAGE is set")
 		case c.DefaultReadMaxTurns <= 0:
 			return nil, fmt.Errorf("BACKFLOW_DEFAULT_READ_MAX_TURNS must be > 0 when BACKFLOW_READER_IMAGE is set")
+		}
+	}
+
+	if c.ResendAPIKey != "" || c.NotifyEmailFrom != "" || c.NotifyEmailTo != "" {
+		switch {
+		case c.ResendAPIKey == "":
+			return nil, fmt.Errorf("BACKFLOW_RESEND_API_KEY is required when BACKFLOW_NOTIFY_EMAIL_FROM or BACKFLOW_NOTIFY_EMAIL_TO is set")
+		case c.NotifyEmailFrom == "":
+			return nil, fmt.Errorf("BACKFLOW_NOTIFY_EMAIL_FROM is required when BACKFLOW_RESEND_API_KEY or BACKFLOW_NOTIFY_EMAIL_TO is set")
+		case c.NotifyEmailTo == "":
+			return nil, fmt.Errorf("BACKFLOW_NOTIFY_EMAIL_TO is required when BACKFLOW_RESEND_API_KEY or BACKFLOW_NOTIFY_EMAIL_FROM is set")
+		case !strings.Contains(c.NotifyEmailFrom, "@"):
+			return nil, fmt.Errorf("BACKFLOW_NOTIFY_EMAIL_FROM must contain '@'")
+		case !strings.Contains(c.NotifyEmailTo, "@"):
+			return nil, fmt.Errorf("BACKFLOW_NOTIFY_EMAIL_TO must contain '@'")
 		}
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -204,3 +204,112 @@ func TestLoad_ReaderImage_RequiresReadMaxTurns(t *testing.T) {
 		t.Errorf("error should name the missing env var, got: %v", err)
 	}
 }
+
+func setNotifyEnv(t *testing.T) {
+	t.Helper()
+	setBaseEnv(t)
+	t.Setenv("BACKFLOW_RESEND_API_KEY", "re_test")
+	t.Setenv("BACKFLOW_NOTIFY_EMAIL_FROM", "from@example.com")
+	t.Setenv("BACKFLOW_NOTIFY_EMAIL_TO", "to@example.com")
+}
+
+func TestLoad_NotifyConfig(t *testing.T) {
+	setNotifyEnv(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+	if cfg.ResendAPIKey != "re_test" {
+		t.Errorf("ResendAPIKey = %q, want %q", cfg.ResendAPIKey, "re_test")
+	}
+	if cfg.NotifyEmailFrom != "from@example.com" {
+		t.Errorf("NotifyEmailFrom = %q, want %q", cfg.NotifyEmailFrom, "from@example.com")
+	}
+	if cfg.NotifyEmailTo != "to@example.com" {
+		t.Errorf("NotifyEmailTo = %q, want %q", cfg.NotifyEmailTo, "to@example.com")
+	}
+}
+
+func TestLoad_NotifyConfig_AllUnset(t *testing.T) {
+	setBaseEnv(t)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned error: %v", err)
+	}
+	if cfg.ResendAPIKey != "" {
+		t.Errorf("ResendAPIKey = %q, want empty when unset", cfg.ResendAPIKey)
+	}
+	if cfg.NotifyEmailFrom != "" {
+		t.Errorf("NotifyEmailFrom = %q, want empty when unset", cfg.NotifyEmailFrom)
+	}
+	if cfg.NotifyEmailTo != "" {
+		t.Errorf("NotifyEmailTo = %q, want empty when unset", cfg.NotifyEmailTo)
+	}
+}
+
+func TestLoad_NotifyConfig_RequiresResendAPIKey(t *testing.T) {
+	setNotifyEnv(t)
+	t.Setenv("BACKFLOW_RESEND_API_KEY", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when BACKFLOW_RESEND_API_KEY is unset with email vars")
+	}
+	if !strings.Contains(err.Error(), "BACKFLOW_RESEND_API_KEY") {
+		t.Errorf("error should name the missing env var, got: %v", err)
+	}
+}
+
+func TestLoad_NotifyConfig_RequiresEmailFrom(t *testing.T) {
+	setNotifyEnv(t)
+	t.Setenv("BACKFLOW_NOTIFY_EMAIL_FROM", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when BACKFLOW_NOTIFY_EMAIL_FROM is unset with other notify vars")
+	}
+	if !strings.Contains(err.Error(), "BACKFLOW_NOTIFY_EMAIL_FROM") {
+		t.Errorf("error should name the missing env var, got: %v", err)
+	}
+}
+
+func TestLoad_NotifyConfig_RequiresEmailTo(t *testing.T) {
+	setNotifyEnv(t)
+	t.Setenv("BACKFLOW_NOTIFY_EMAIL_TO", "")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when BACKFLOW_NOTIFY_EMAIL_TO is unset with other notify vars")
+	}
+	if !strings.Contains(err.Error(), "BACKFLOW_NOTIFY_EMAIL_TO") {
+		t.Errorf("error should name the missing env var, got: %v", err)
+	}
+}
+
+func TestLoad_NotifyConfig_FromMissingAt(t *testing.T) {
+	setNotifyEnv(t)
+	t.Setenv("BACKFLOW_NOTIFY_EMAIL_FROM", "notanemail")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when BACKFLOW_NOTIFY_EMAIL_FROM lacks '@'")
+	}
+	if !strings.Contains(err.Error(), "BACKFLOW_NOTIFY_EMAIL_FROM") || !strings.Contains(err.Error(), "@") {
+		t.Errorf("error should name the var and mention '@', got: %v", err)
+	}
+}
+
+func TestLoad_NotifyConfig_ToMissingAt(t *testing.T) {
+	setNotifyEnv(t)
+	t.Setenv("BACKFLOW_NOTIFY_EMAIL_TO", "notanemail")
+
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected error when BACKFLOW_NOTIFY_EMAIL_TO lacks '@'")
+	}
+	if !strings.Contains(err.Error(), "BACKFLOW_NOTIFY_EMAIL_TO") || !strings.Contains(err.Error(), "@") {
+		t.Errorf("error should name the var and mention '@', got: %v", err)
+	}
+}

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -154,6 +154,9 @@ var reservedEnvVarKeys = map[string]bool{
 	"ANTHROPIC_API_KEY":     true,
 	"OPENAI_API_KEY":        true,
 	"GITHUB_TOKEN":          true,
+	"RESEND_API_KEY":        true,
+	"NOTIFY_EMAIL_FROM":     true,
+	"NOTIFY_EMAIL_TO":       true,
 }
 
 // containsNullByte returns true if s contains a null byte, which PostgreSQL

--- a/internal/models/task_test.go
+++ b/internal/models/task_test.go
@@ -218,6 +218,21 @@ func TestCreateTaskRequestValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "reserved env var key RESEND_API_KEY",
+			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"RESEND_API_KEY": "re_attacker"}},
+			wantErr: true,
+		},
+		{
+			name:    "reserved env var key NOTIFY_EMAIL_FROM",
+			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"NOTIFY_EMAIL_FROM": "evil@attacker.com"}},
+			wantErr: true,
+		},
+		{
+			name:    "reserved env var key NOTIFY_EMAIL_TO",
+			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"NOTIFY_EMAIL_TO": "victim@attacker.com"}},
+			wantErr: true,
+		},
+		{
 			name:    "non-reserved env var key allowed",
 			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"MY_CUSTOM_VAR": "val"}},
 			wantErr: false,

--- a/internal/orchestrator/docker/docker.go
+++ b/internal/orchestrator/docker/docker.go
@@ -186,6 +186,15 @@ func (m *Manager) buildSecretEnvPairs(task *models.Task) []string {
 	if m.config.APIKey != "" {
 		pairs = append(pairs, "BACKFLOW_API_KEY="+m.config.APIKey)
 	}
+	if m.config.ResendAPIKey != "" {
+		pairs = append(pairs, "RESEND_API_KEY="+m.config.ResendAPIKey)
+	}
+	if m.config.NotifyEmailFrom != "" {
+		pairs = append(pairs, "NOTIFY_EMAIL_FROM="+m.config.NotifyEmailFrom)
+	}
+	if m.config.NotifyEmailTo != "" {
+		pairs = append(pairs, "NOTIFY_EMAIL_TO="+m.config.NotifyEmailTo)
+	}
 	return pairs
 }
 

--- a/internal/orchestrator/docker/docker_test.go
+++ b/internal/orchestrator/docker/docker_test.go
@@ -392,6 +392,41 @@ func TestBuildSecretEnvPairs_NoSecrets(t *testing.T) {
 	}
 }
 
+func TestBuildSecretEnvPairs_IncludesResendVars(t *testing.T) {
+	cfg := &config.Config{
+		ResendAPIKey:    "re_test",
+		NotifyEmailFrom: "from@example.com",
+		NotifyEmailTo:   "to@example.com",
+	}
+	dm := NewManager(cfg)
+
+	pairs := dm.buildSecretEnvPairs(&models.Task{ID: "bf_01ABC"})
+
+	for _, want := range []string{
+		"RESEND_API_KEY=re_test",
+		"NOTIFY_EMAIL_FROM=from@example.com",
+		"NOTIFY_EMAIL_TO=to@example.com",
+	} {
+		if !contains(pairs, want) {
+			t.Errorf("expected %q in secret env pairs, got %v", want, pairs)
+		}
+	}
+}
+
+func TestBuildSecretEnvPairs_OmitsResendVarsWhenUnset(t *testing.T) {
+	cfg := &config.Config{}
+	dm := NewManager(cfg)
+
+	pairs := dm.buildSecretEnvPairs(&models.Task{ID: "bf_01ABC"})
+
+	joined := strings.Join(pairs, "\n")
+	for _, key := range []string{"RESEND_API_KEY", "NOTIFY_EMAIL_FROM", "NOTIFY_EMAIL_TO"} {
+		if strings.Contains(joined, key) {
+			t.Errorf("env-file must not contain %q when unset, got %v", key, pairs)
+		}
+	}
+}
+
 func TestWriteEnvFile(t *testing.T) {
 	pairs := []string{"FOO=bar", "BAZ=qux with spaces"}
 	path, err := writeEnvFile(pairs)


### PR DESCRIPTION
## Summary

First slice of email-summary delivery (parent PRD #19, slice #60). Stands up the end-to-end path from Backflow config to a real Resend send from inside the read skill, so a `claude_code` read task on the skill-agent image with valid Resend config drops a plain-text email containing the page title and TL;DR in the operator's inbox.

After this lands, body richness, hostname-fallback subject, retries, and idempotency follow in Slices 2 and 3. The locus is deliberately the **read skill bundle** (not the orchestrator), so future template changes live in one place.

## What changed

**Config (`internal/config/config.go` + tests)**
- New fields `ResendAPIKey`, `NotifyEmailFrom`, `NotifyEmailTo` populated from `BACKFLOW_RESEND_API_KEY`, `BACKFLOW_NOTIFY_EMAIL_FROM`, `BACKFLOW_NOTIFY_EMAIL_TO`.
- All-or-nothing gate in `Load()`: if any of the three is set, all must be set, with named-var errors. Both addresses must contain `@` (cheap typo check).
- All-three-unset is silently disabled.

**Reserved env keys (`internal/models/task.go` + tests)**
- `RESEND_API_KEY`, `NOTIFY_EMAIL_FROM`, `NOTIFY_EMAIL_TO` added to `reservedEnvVarKeys` so per-task `env_vars` cannot override them.

**Orchestrator env-file plumbing (`internal/orchestrator/docker/docker.go` + tests)**
- `buildSecretEnvPairs` appends the three vars (without the `BACKFLOW_` prefix) when configured, alongside `OPENAI_API_KEY`. Vars are absent — not empty — when unset, so no env-file pollution.

**`docker/skill-agent/skills/read/send-email.sh` (new)**
- Bash + curl, mirrors `read-embed.sh` shape.
- Single `POST ${RESEND_BASE_URL:-https://api.resend.com}/emails` with `Authorization: Bearer`, `Content-Type: application/json`, JSON body `{from, to: [...], subject, text}`.
- Subject = page title from `status.json`. Body = URL, title, TL;DR, `Task: <task_id>`. Plain text only.
- Reads `${1:-$HOME/workspace/status.json}` via `jq`.
- No-op `exit 0` with a log line when `RESEND_API_KEY` is unset (or `NOTIFY_EMAIL_FROM`/`TO`, or status file missing). Email failures are advisory — they log and exit 0 without changing task state.

**Read SKILL.md**
- New step 8 instructs the agent to invoke `~/.claude/skills/read/send-email.sh` after `status.json` is written. Safe to invoke unconditionally (no-op when secret unset).

**Operator docs (`docs/resend-setup.md`, new)**
- Walkthrough: Resend account + API key, sender-domain DNS (SPF + DKIM CNAMEs), env vars, all-or-nothing gating, scope (`claude_code` + skill-agent + read mode only — codex read tasks excluded), and how to verify delivery.
- Cross-linked from the `## Documentation` list in root `CLAUDE.md`.
- `.env.example` documents the three commented-out vars with a pointer to the new doc.

**Shell test harness (`docker/skill-agent/test_entrypoint.sh`)**
- Two new tests under `make test-skill-agent-entrypoint`, both spinning up an in-process Python `http.server` as a fake Resend:
  1. Happy path — asserts method `POST`, path `/emails`, `Authorization: Bearer …`, `Content-Type: application/json`, and JSON body fields (`from`, `to[0]`, `subject` matching title, `text` containing URL/title/TL;DR/`Task: bf_…`).
  2. No-op path — `RESEND_API_KEY` unset; asserts exit 0 and the fake server received no request.

## Out of scope (deferred)

- Rich body (`summary_markdown`, tags, keywords, people, orgs, connections, novelty verdict) and hostname-fallback subject — Slice 2.
- Retry on 5xx + `Idempotency-Key` header — Slice 3.
- Codex read tasks (route to `docker/reader/`, not the skill-agent image).
- Container-level failures where the skill never runs — those still notify via the existing webhook + DB.
- Live integration test against real Resend (PRD explicitly rejects).

## Test plan

- [x] `make test` — 16 packages OK (config + models + orchestrator/docker tests cover the new code).
- [x] `make lint` — clean.
- [x] `make test-skill-agent-entrypoint` — 14 PASS including the two new fake-Resend tests.
- [ ] **End-to-end smoke** (operator-side, not part of CI): with all three `BACKFLOW_RESEND_*`/`BACKFLOW_NOTIFY_*` vars set against a verified sender domain and `BACKFLOW_SKILL_AGENT_IMAGE` set, submit a `claude_code` read task and confirm the email arrives with the expected subject/body. Requires `make build && make docker-skill-agent-build-local` and a server restart for the skill bundle changes to take effect.

Closes #60.