### PR TITLE
feat(readings): search, tag filter, related panel, originating-task context

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -85,7 +85,11 @@ paths:
     get:
       operationId: listReadings
       summary: List saved readings
-      description: Returns saved reading results newest-first with offset pagination. Requires bearer authentication when API keys are configured.
+      description: >
+        Returns saved reading results newest-first with offset pagination.
+        Optionally filtered by a free-text query (`q`) that matches against
+        title, url, tldr, and summary. Requires bearer authentication when API
+        keys are configured.
       parameters:
         - name: limit
           in: query
@@ -102,6 +106,18 @@ paths:
           schema:
             type: integer
             minimum: 0
+        - name: q
+          in: query
+          description: Free-text query matched case-insensitively against title, url, tldr, and summary.
+          required: false
+          schema:
+            type: string
+        - name: tag
+          in: query
+          description: Restrict results to readings whose tags array contains this tag (case-insensitive exact match).
+          required: false
+          schema:
+            type: string
       responses:
         "200":
           description: Page of saved readings
@@ -721,7 +737,7 @@ components:
       required: [data]
       properties:
         data:
-          $ref: "#/components/schemas/Reading"
+          $ref: "#/components/schemas/ReadingDetail"
 
     ReadingPage:
       type: object
@@ -1090,3 +1106,67 @@ components:
         reason:
           type: string
           example: "Covers the same deployment pattern."
+
+    ReadingDetail:
+      description: >
+        Reading detail used by the reading-library SPA. Extends Reading with
+        connections resolved against the readings table (related[]) and a
+        snapshot of the task that produced the reading.
+      allOf:
+        - $ref: "#/components/schemas/Reading"
+        - type: object
+          required: [related]
+          properties:
+            related:
+              type: array
+              items:
+                $ref: "#/components/schemas/RelatedReading"
+            originating_task:
+              nullable: true
+              $ref: "#/components/schemas/OriginatingTaskInfo"
+
+    RelatedReading:
+      type: object
+      required: [reading_id, reason, title, tldr, url, novelty_verdict]
+      description: A connection that has been resolved to the linked reading's display fields.
+      properties:
+        reading_id:
+          type: string
+        reason:
+          type: string
+        title:
+          type: string
+        tldr:
+          type: string
+        url:
+          type: string
+          format: uri
+        novelty_verdict:
+          type: string
+
+    OriginatingTaskInfo:
+      type: object
+      required: [id, status, task_mode, repo_url, pr_url, output_url, error, created_at]
+      description: Snapshot of the task that produced the reading.
+      properties:
+        id:
+          type: string
+        status:
+          $ref: "#/components/schemas/TaskStatus"
+        task_mode:
+          type: string
+          enum: [auto, code, review, read]
+        repo_url:
+          type: string
+        pr_url:
+          type: string
+        output_url:
+          type: string
+        error:
+          type: string
+        created_at:
+          type: string
+          format: date-time
+        completed_at:
+          type: string
+          format: date-time

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -65,6 +65,36 @@ type readingResponse struct {
 	CreatedAt      time.Time           `json:"created_at"`
 }
 
+// readingDetailResponse extends readingResponse with the discovery surface used
+// by the detail view: connections resolved to their target reading bodies and
+// a snapshot of the task that produced this reading.
+type readingDetailResponse struct {
+	readingResponse
+	Related         []relatedReading     `json:"related"`
+	OriginatingTask *originatingTaskInfo `json:"originating_task"`
+}
+
+type relatedReading struct {
+	ReadingID      string `json:"reading_id"`
+	Reason         string `json:"reason"`
+	Title          string `json:"title"`
+	TLDR           string `json:"tldr"`
+	URL            string `json:"url"`
+	NoveltyVerdict string `json:"novelty_verdict"`
+}
+
+type originatingTaskInfo struct {
+	ID          string     `json:"id"`
+	Status      string     `json:"status"`
+	TaskMode    string     `json:"task_mode"`
+	RepoURL     string     `json:"repo_url"`
+	PRURL       string     `json:"pr_url"`
+	OutputURL   string     `json:"output_url"`
+	Error       string     `json:"error"`
+	CreatedAt   time.Time  `json:"created_at"`
+	CompletedAt *time.Time `json:"completed_at,omitempty"`
+}
+
 func NewHandlers(s store.Store, cfg *config.Config, logs LogFetcher, bus notify.Emitter) *Handlers {
 	return &Handlers{store: s, config: cfg, logs: logs, bus: bus}
 }
@@ -150,6 +180,8 @@ func (h *Handlers) ListReadings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	readings, err := h.store.ListReadings(r.Context(), store.ReadingFilter{
+		Search: r.URL.Query().Get("q"),
+		Tag:    r.URL.Query().Get("tag"),
 		Limit:  limit + 1,
 		Offset: offset,
 	})
@@ -180,7 +212,60 @@ func (h *Handlers) GetReading(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "failed to get reading")
 		return
 	}
-	writeJSON(w, http.StatusOK, newReadingResponse(reading))
+
+	related := make([]relatedReading, 0, len(reading.Connections))
+	for _, conn := range reading.Connections {
+		if conn.ReadingID == "" {
+			continue
+		}
+		target, err := h.store.GetReading(r.Context(), conn.ReadingID)
+		if errors.Is(err, store.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to resolve related reading")
+			return
+		}
+		related = append(related, relatedReading{
+			ReadingID:      target.ID,
+			Reason:         conn.Reason,
+			Title:          target.Title,
+			TLDR:           target.TLDR,
+			URL:            target.URL,
+			NoveltyVerdict: target.NoveltyVerdict,
+		})
+	}
+
+	var originating *originatingTaskInfo
+	if reading.TaskID != "" {
+		task, err := h.store.GetTask(r.Context(), reading.TaskID)
+		switch {
+		case err == nil:
+			originating = &originatingTaskInfo{
+				ID:          task.ID,
+				Status:      string(task.Status),
+				TaskMode:    task.TaskMode,
+				RepoURL:     task.RepoURL,
+				PRURL:       task.PRURL,
+				OutputURL:   task.OutputURL,
+				Error:       task.Error,
+				CreatedAt:   task.CreatedAt,
+				CompletedAt: task.CompletedAt,
+			}
+		case errors.Is(err, store.ErrNotFound):
+			// Reading outlived its parent task — surface as null so the UI
+			// can render an "unavailable" state.
+		default:
+			writeError(w, http.StatusInternalServerError, "failed to resolve originating task")
+			return
+		}
+	}
+
+	writeJSON(w, http.StatusOK, readingDetailResponse{
+		readingResponse: newReadingResponse(reading),
+		Related:         related,
+		OriginatingTask: originating,
+	})
 }
 
 func readingResponses(readings []*models.Reading) []readingResponse {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -703,6 +703,394 @@ func TestGetReading_NormalizesNilCollections(t *testing.T) {
 	}
 }
 
+func TestListReadings_FiltersByQueryAcrossSearchableFields(t *testing.T) {
+	srv, s, _ := testServerWithEmitter(t)
+	ctx := context.Background()
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	task := &models.Task{
+		ID:        "bf_READ_Q_TASK",
+		Status:    models.TaskStatusCompleted,
+		TaskMode:  models.TaskModeRead,
+		Harness:   models.HarnessClaudeCode,
+		Prompt:    "https://example.com/q",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	seeds := []struct {
+		id      string
+		url     string
+		title   string
+		tldr    string
+		summary string
+	}{
+		{"bf_READ_Q_TITLE", "https://example.com/a", "SQLite Internals", "no match here", "different body"},
+		{"bf_READ_Q_URL", "https://example.com/sqlite-tips", "Other", "no match here", "different body"},
+		{"bf_READ_Q_TLDR", "https://example.com/c", "Other", "Mostly about SQLite under the hood", "different body"},
+		{"bf_READ_Q_SUMMARY", "https://example.com/d", "Other", "no match here", "Deep dive into sqlite query planning"},
+		{"bf_READ_Q_NONE", "https://example.com/e", "Postgres", "MVCC overview", "Postgres write-ahead log"},
+	}
+	for i, seed := range seeds {
+		r := &models.Reading{
+			ID:             seed.id,
+			TaskID:         task.ID,
+			URL:            seed.url,
+			Title:          seed.title,
+			TLDR:           seed.tldr,
+			Tags:           []string{},
+			Keywords:       []string{},
+			People:         []string{},
+			Orgs:           []string{},
+			NoveltyVerdict: "new",
+			Connections:    []models.Connection{},
+			Summary:        seed.summary,
+			RawOutput:      []byte(`{}`),
+			CreatedAt:      now.Add(time.Duration(i) * time.Minute),
+		}
+		if err := s.UpsertReading(ctx, r); err != nil {
+			t.Fatalf("UpsertReading %s: %v", seed.id, err)
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/readings?q=sqlite", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	checkResponse(t, req, w)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			Readings []models.Reading `json:"readings"`
+			HasMore  bool             `json:"has_more"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := make(map[string]bool, len(resp.Data.Readings))
+	for _, r := range resp.Data.Readings {
+		got[r.ID] = true
+	}
+	wantHits := []string{"bf_READ_Q_TITLE", "bf_READ_Q_URL", "bf_READ_Q_TLDR", "bf_READ_Q_SUMMARY"}
+	for _, id := range wantHits {
+		if !got[id] {
+			t.Errorf("missing match for %s; got ids %v", id, keys(got))
+		}
+	}
+	if got["bf_READ_Q_NONE"] {
+		t.Errorf("non-matching reading returned; got ids %v", keys(got))
+	}
+}
+
+func keys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func TestListReadings_FiltersByTagAndCombinesWithQuery(t *testing.T) {
+	srv, s, _ := testServerWithEmitter(t)
+	ctx := context.Background()
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+	task := &models.Task{
+		ID:        "bf_READ_TAG_TASK",
+		Status:    models.TaskStatusCompleted,
+		TaskMode:  models.TaskModeRead,
+		Harness:   models.HarnessClaudeCode,
+		Prompt:    "https://example.com/tag",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	seeds := []struct {
+		id    string
+		title string
+		tags  []string
+	}{
+		{"bf_READ_TAG_GO", "Go SQLite Tips", []string{"go", "sqlite"}},
+		{"bf_READ_TAG_RUST", "Rust SQLite Tips", []string{"rust", "sqlite"}},
+		{"bf_READ_TAG_GO_OTHER", "Go Concurrency", []string{"go", "concurrency"}},
+		{"bf_READ_TAG_PG", "Postgres MVCC", []string{"postgres"}},
+	}
+	for i, seed := range seeds {
+		r := &models.Reading{
+			ID:             seed.id,
+			TaskID:         task.ID,
+			URL:            "https://example.com/" + seed.id,
+			Title:          seed.title,
+			TLDR:           seed.title + " tldr",
+			Tags:           seed.tags,
+			Keywords:       []string{},
+			People:         []string{},
+			Orgs:           []string{},
+			NoveltyVerdict: "new",
+			Connections:    []models.Connection{},
+			Summary:        seed.title + " summary",
+			RawOutput:      []byte(`{}`),
+			CreatedAt:      now.Add(time.Duration(i) * time.Minute),
+		}
+		if err := s.UpsertReading(ctx, r); err != nil {
+			t.Fatalf("UpsertReading %s: %v", seed.id, err)
+		}
+	}
+
+	// tag-only filter returns both go-tagged readings.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/readings?tag=go", nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	checkResponse(t, req, w)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp struct {
+		Data struct {
+			Readings []models.Reading `json:"readings"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	got := make(map[string]bool, len(resp.Data.Readings))
+	for _, r := range resp.Data.Readings {
+		got[r.ID] = true
+	}
+	for _, want := range []string{"bf_READ_TAG_GO", "bf_READ_TAG_GO_OTHER"} {
+		if !got[want] {
+			t.Errorf("missing %s for tag=go; got %v", want, keys(got))
+		}
+	}
+	for _, unwanted := range []string{"bf_READ_TAG_RUST", "bf_READ_TAG_PG"} {
+		if got[unwanted] {
+			t.Errorf("unexpected %s in tag=go results; got %v", unwanted, keys(got))
+		}
+	}
+
+	// q + tag combine: only Go readings whose title mentions sqlite.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/readings?tag=go&q=sqlite", nil)
+	w2 := httptest.NewRecorder()
+	srv.ServeHTTP(w2, req2)
+	checkResponse(t, req2, w2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("combined filter status = %d, body: %s", w2.Code, w2.Body.String())
+	}
+	var resp2 struct {
+		Data struct {
+			Readings []models.Reading `json:"readings"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w2.Body).Decode(&resp2); err != nil {
+		t.Fatalf("decode combined: %v", err)
+	}
+	if len(resp2.Data.Readings) != 1 || resp2.Data.Readings[0].ID != "bf_READ_TAG_GO" {
+		ids := make([]string, 0, len(resp2.Data.Readings))
+		for _, r := range resp2.Data.Readings {
+			ids = append(ids, r.ID)
+		}
+		t.Fatalf("combined filter returned %v, want [bf_READ_TAG_GO]", ids)
+	}
+}
+
+func TestGetReading_IncludesResolvedRelatedAndOriginatingTask(t *testing.T) {
+	srv, s, _ := testServerWithEmitter(t)
+	ctx := context.Background()
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+
+	originatingTask := &models.Task{
+		ID:        "bf_TASK_PARENT",
+		Status:    models.TaskStatusCompleted,
+		TaskMode:  models.TaskModeRead,
+		Harness:   models.HarnessClaudeCode,
+		RepoURL:   "https://example.com/article",
+		Prompt:    "https://example.com/article",
+		OutputURL: "/api/v1/tasks/bf_TASK_PARENT/output",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.CreateTask(ctx, originatingTask); err != nil {
+		t.Fatalf("CreateTask parent: %v", err)
+	}
+
+	relatedTask := &models.Task{
+		ID:        "bf_TASK_RELATED",
+		Status:    models.TaskStatusCompleted,
+		TaskMode:  models.TaskModeRead,
+		Harness:   models.HarnessClaudeCode,
+		Prompt:    "https://example.com/related",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.CreateTask(ctx, relatedTask); err != nil {
+		t.Fatalf("CreateTask related: %v", err)
+	}
+
+	relatedReading := &models.Reading{
+		ID:             "bf_READ_RELATED",
+		TaskID:         relatedTask.ID,
+		URL:            "https://example.com/related",
+		Title:          "Related Reading Title",
+		TLDR:           "Related TL;DR",
+		Tags:           []string{"backend"},
+		Keywords:       []string{},
+		People:         []string{},
+		Orgs:           []string{},
+		NoveltyVerdict: "new",
+		Connections:    []models.Connection{},
+		Summary:        "Related summary",
+		RawOutput:      []byte(`{}`),
+		CreatedAt:      now,
+	}
+	if err := s.UpsertReading(ctx, relatedReading); err != nil {
+		t.Fatalf("UpsertReading related: %v", err)
+	}
+
+	subjectReading := &models.Reading{
+		ID:             "bf_READ_SUBJECT",
+		TaskID:         originatingTask.ID,
+		URL:            "https://example.com/article",
+		Title:          "Subject",
+		TLDR:           "Subject tldr",
+		Tags:           []string{"backend"},
+		Keywords:       []string{},
+		People:         []string{},
+		Orgs:           []string{},
+		NoveltyVerdict: "new",
+		Connections: []models.Connection{
+			{ReadingID: "bf_READ_RELATED", Reason: "covers same topic"},
+			{ReadingID: "bf_READ_DANGLING", Reason: "no longer exists"},
+		},
+		Summary:   "Subject summary",
+		RawOutput: []byte(`{}`),
+		CreatedAt: now,
+	}
+	if err := s.UpsertReading(ctx, subjectReading); err != nil {
+		t.Fatalf("UpsertReading subject: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/readings/"+subjectReading.ID, nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	checkResponse(t, req, w)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+	}
+
+	type relatedItem struct {
+		ReadingID      string `json:"reading_id"`
+		Reason         string `json:"reason"`
+		Title          string `json:"title"`
+		TLDR           string `json:"tldr"`
+		URL            string `json:"url"`
+		NoveltyVerdict string `json:"novelty_verdict"`
+	}
+	type originatingTaskInfo struct {
+		ID        string `json:"id"`
+		Status    string `json:"status"`
+		RepoURL   string `json:"repo_url"`
+		PRURL     string `json:"pr_url"`
+		OutputURL string `json:"output_url"`
+		Error     string `json:"error"`
+	}
+	var resp struct {
+		Data struct {
+			ID              string               `json:"id"`
+			Related         []relatedItem        `json:"related"`
+			OriginatingTask *originatingTaskInfo `json:"originating_task"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(resp.Data.Related) != 1 {
+		t.Fatalf("related = %#v, want exactly the resolvable connection", resp.Data.Related)
+	}
+	got := resp.Data.Related[0]
+	if got.ReadingID != "bf_READ_RELATED" || got.Title != "Related Reading Title" ||
+		got.TLDR != "Related TL;DR" || got.URL != "https://example.com/related" ||
+		got.Reason != "covers same topic" {
+		t.Fatalf("related[0] = %#v, want resolved reading data + reason", got)
+	}
+
+	if resp.Data.OriginatingTask == nil {
+		t.Fatalf("originating_task = nil, want resolved task")
+	}
+	if resp.Data.OriginatingTask.ID != originatingTask.ID || resp.Data.OriginatingTask.Status != string(models.TaskStatusCompleted) {
+		t.Fatalf("originating_task = %#v, want id %q status completed", resp.Data.OriginatingTask, originatingTask.ID)
+	}
+	if resp.Data.OriginatingTask.OutputURL != originatingTask.OutputURL {
+		t.Fatalf("originating_task.output_url = %q, want %q", resp.Data.OriginatingTask.OutputURL, originatingTask.OutputURL)
+	}
+}
+
+func TestGetReading_NoConnectionsAndAllDanglingReturnsEmptyRelated(t *testing.T) {
+	srv, s, _ := testServerWithEmitter(t)
+	ctx := context.Background()
+	now := time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC)
+
+	task := &models.Task{
+		ID:        "bf_TASK_NO_CONN",
+		Status:    models.TaskStatusCompleted,
+		TaskMode:  models.TaskModeRead,
+		Harness:   models.HarnessClaudeCode,
+		Prompt:    "https://example.com/no-conn",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	reading := &models.Reading{
+		ID:             "bf_READ_NO_CONN",
+		TaskID:         task.ID,
+		URL:            "https://example.com/no-conn",
+		Title:          "No connections",
+		TLDR:           "no related",
+		Tags:           []string{},
+		Keywords:       []string{},
+		People:         []string{},
+		Orgs:           []string{},
+		NoveltyVerdict: "new",
+		// One connection that points at a never-stored reading; should be
+		// dropped from the resolved related[] payload.
+		Connections: []models.Connection{
+			{ReadingID: "bf_READ_DANGLING", Reason: "dropped"},
+		},
+		Summary:   "no connections summary",
+		RawOutput: []byte(`{}`),
+		CreatedAt: now,
+	}
+	if err := s.UpsertReading(ctx, reading); err != nil {
+		t.Fatalf("UpsertReading: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/readings/"+reading.ID, nil)
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, req)
+	checkResponse(t, req, w)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+	}
+
+	bodyBytes := w.Body.Bytes()
+	if !bytes.Contains(bodyBytes, []byte(`"related":[]`)) {
+		t.Fatalf("expected related to be an empty array; body: %s", string(bodyBytes))
+	}
+	if !bytes.Contains(bodyBytes, []byte(`"originating_task":`)) {
+		t.Fatalf("expected originating_task key in body: %s", string(bodyBytes))
+	}
+}
+
 // TestFindSimilarReadings_EmptyResultReturnsDataArray mirrors the lookup test
 // for the POST similarity endpoint.
 func TestFindSimilarReadings_EmptyResultReturnsDataArray(t *testing.T) {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -420,8 +420,30 @@ const readingColumns = `id, task_id, url, title, tldr,
 	created_at`
 
 func (s *SQLiteStore) ListReadings(ctx context.Context, filter ReadingFilter) ([]*models.Reading, error) {
-	query := "SELECT " + readingColumns + " FROM readings ORDER BY created_at DESC, id ASC"
-	var args []any
+	query := "SELECT " + readingColumns + " FROM readings"
+	var (
+		conds []string
+		args  []any
+	)
+	if search := strings.TrimSpace(filter.Search); search != "" {
+		// Wildcard LIKE on the searchable text columns. SQLite's LIKE is
+		// case-insensitive for ASCII by default, which is enough for the
+		// title/url/tldr/summary fields exposed today.
+		conds = append(conds, `(title LIKE ? OR url LIKE ? OR tldr LIKE ? OR summary LIKE ?)`)
+		needle := "%" + search + "%"
+		args = append(args, needle, needle, needle, needle)
+	}
+	if tag := strings.TrimSpace(filter.Tag); tag != "" {
+		// Tags are stored as a JSON text array (e.g. ["go","sqlite"]).
+		// json_each + lower() gives an exact, case-insensitive match without
+		// the false positives a substring LIKE would produce.
+		conds = append(conds, `EXISTS (SELECT 1 FROM json_each(readings.tags) WHERE lower(json_each.value) = lower(?))`)
+		args = append(args, tag)
+	}
+	if len(conds) > 0 {
+		query += " WHERE " + strings.Join(conds, " AND ")
+	}
+	query += " ORDER BY created_at DESC, id ASC"
 	if filter.Limit > 0 {
 		query += " LIMIT ?"
 		args = append(args, filter.Limit)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -32,6 +32,12 @@ type TaskFilter struct {
 
 // ReadingFilter controls reading-library listing behavior.
 type ReadingFilter struct {
+	// Search restricts results to readings whose title, url, tldr, or summary
+	// contain the substring (case-insensitive). Empty means no filter.
+	Search string
+	// Tag restricts results to readings whose tags array contains the tag
+	// (case-insensitive). Empty means no filter.
+	Tag    string
 	Limit  int
 	Offset int
 }

--- a/web/src/App.test.tsx
+++ b/web/src/App.test.tsx
@@ -52,6 +52,27 @@ const readingDetail = {
     orgs: ["Backlite"],
     novelty_verdict: "new",
     connections: [{ reading_id: "bf_READ_TWO", reason: "same operations theme" }],
+    related: [
+      {
+        reading_id: "bf_READ_TWO",
+        reason: "same operations theme",
+        title: "Related Notes",
+        tldr: "Companion summary for operators",
+        url: "https://example.com/related",
+        novelty_verdict: "extends_existing"
+      }
+    ],
+    originating_task: {
+      id: "bf_TASK_ONE",
+      status: "completed",
+      task_mode: "read",
+      repo_url: "",
+      pr_url: "",
+      output_url: "/api/v1/tasks/bf_TASK_ONE/output",
+      error: "",
+      created_at: "2026-04-25T15:30:00Z",
+      completed_at: "2026-04-25T15:35:00Z"
+    },
     summary: "A detailed summary for operators reviewing saved reading results.",
     created_at: "2026-04-25T16:00:00Z"
   }
@@ -146,5 +167,116 @@ describe("App", () => {
     expect(orgSection).not.toBeNull();
     expect(within(orgSection as HTMLElement).getByText("Backlite")).toBeInTheDocument();
     expect(screen.getByText("same operations theme")).toBeInTheDocument();
+  });
+
+  it("submits a search query and refetches with q on the request URL", async () => {
+    const fetchMock = vi.fn(async (_request: Request) => jsonResponse(readingPage));
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+
+    render(<App initialPath="/" />);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    const initialUrl = new URL(fetchMock.mock.calls[0][0].url);
+    expect(initialUrl.searchParams.get("q")).toBeNull();
+
+    const searchInput = screen.getByLabelText("Search readings");
+    await user.type(searchInput, "sqlite");
+    await user.click(screen.getByRole("button", { name: "Search" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const refetchUrl = new URL(fetchMock.mock.calls[1][0].url);
+    expect(refetchUrl.searchParams.get("q")).toBe("sqlite");
+  });
+
+  it("hydrates the search input from the URL ?q= param", async () => {
+    stubJSON(readingPage);
+
+    render(<App initialPath="/?q=cached" />);
+
+    const input = (await screen.findByLabelText("Search readings")) as HTMLInputElement;
+    expect(input.value).toBe("cached");
+  });
+
+  it("renders the related readings panel with title, tldr, url, and reason", async () => {
+    stubJSON(readingDetail);
+
+    render(<App initialPath="/readings/bf_READ_ONE" />);
+
+    const heading = await screen.findByRole("heading", { name: "Related Readings" });
+    const panel = heading.closest("section") as HTMLElement;
+    expect(panel).not.toBeNull();
+    const link = within(panel).getByRole("link", { name: "Related Notes" });
+    expect(link).toHaveAttribute("href", "/readings/bf_READ_TWO");
+    expect(within(panel).getByText("Companion summary for operators")).toBeInTheDocument();
+    expect(within(panel).getByText("https://example.com/related")).toBeInTheDocument();
+    expect(within(panel).getByText("same operations theme")).toBeInTheDocument();
+  });
+
+  it("renders the originating task panel with status and output link", async () => {
+    stubJSON(readingDetail);
+
+    render(<App initialPath="/readings/bf_READ_ONE" />);
+
+    const heading = await screen.findByRole("heading", { name: "Originating Task" });
+    const panel = heading.closest("section") as HTMLElement;
+    expect(within(panel).getByText("bf_TASK_ONE")).toBeInTheDocument();
+    expect(within(panel).getByText(/completed/i)).toBeInTheDocument();
+    const outputLink = within(panel).getByRole("link", { name: /agent output/i });
+    expect(outputLink).toHaveAttribute("href", "/api/v1/tasks/bf_TASK_ONE/output");
+  });
+
+  it("renders an unavailable state when the originating task is null", async () => {
+    stubJSON({
+      data: {
+        ...readingDetail.data,
+        originating_task: null
+      }
+    });
+
+    render(<App initialPath="/readings/bf_READ_ONE" />);
+
+    const heading = await screen.findByRole("heading", { name: "Originating Task" });
+    const panel = heading.closest("section") as HTMLElement;
+    expect(within(panel).getByText(/originating task is unavailable/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty state when no related readings are returned", async () => {
+    stubJSON({
+      data: {
+        ...readingDetail.data,
+        connections: [],
+        related: []
+      }
+    });
+
+    render(<App initialPath="/readings/bf_READ_ONE" />);
+
+    const heading = await screen.findByRole("heading", { name: "Related Readings" });
+    const panel = heading.closest("section") as HTMLElement;
+    expect(within(panel).getByText("No related readings yet")).toBeInTheDocument();
+  });
+
+  it("filters by clicking a tag chip and clears with the active-tag control", async () => {
+    const fetchMock = vi.fn(async (_request: Request) => jsonResponse(readingPage));
+    vi.stubGlobal("fetch", fetchMock);
+    const user = userEvent.setup();
+
+    render(<App initialPath="/" />);
+
+    // Click the "agents" tag chip on the first reading row.
+    await user.click(await screen.findByRole("button", { name: "Filter by tag agents" }));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+    const tagUrl = new URL(fetchMock.mock.calls[1][0].url);
+    expect(tagUrl.searchParams.get("tag")).toBe("agents");
+
+    // Active-tag indicator appears and clears the filter when activated.
+    const clearTag = await screen.findByRole("button", { name: /clear tag agents/i });
+    await user.click(clearTag);
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(3));
+    const clearedUrl = new URL(fetchMock.mock.calls[2][0].url);
+    expect(clearedUrl.searchParams.get("tag")).toBeNull();
   });
 });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider, useQuery } from "@tanstack/react-query";
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import {
   BrowserRouter,
   Link,
@@ -7,10 +7,19 @@ import {
   Navigate,
   Route,
   Routes,
-  useParams
+  useParams,
+  useSearchParams
 } from "react-router-dom";
 
-import { ApiError, getReading, listReadings, tokenStorageKey, type Reading } from "./api";
+import {
+  ApiError,
+  getReading,
+  listReadings,
+  tokenStorageKey,
+  type OriginatingTask,
+  type Reading,
+  type RelatedReading
+} from "./api";
 import "./styles.css";
 
 type AppProps = {
@@ -125,11 +134,34 @@ function AuthTokenForm({ token, setToken }: { token: string; setToken: (token: s
 }
 
 function ReadingList({ token }: { token: string }) {
-  const [offset, setOffset] = useState(0);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const q = searchParams.get("q") ?? "";
+  const tag = searchParams.get("tag") ?? "";
+  const offset = parseOffset(searchParams.get("offset"));
+  const [draft, setDraft] = useState(q);
+
+  // Keep the input in sync when the URL changes from elsewhere (back/forward,
+  // tag click, manual edit) so the search box reflects the active query.
+  useEffect(() => {
+    setDraft(q);
+  }, [q]);
+
   const query = useQuery({
-    queryKey: ["readings", token, offset],
-    queryFn: () => listReadings(token, pageSize, offset)
+    queryKey: ["readings", token, q, tag, offset],
+    queryFn: () => listReadings(token, { limit: pageSize, offset, q, tag })
   });
+
+  const updateParams = (patch: Record<string, string | undefined>) => {
+    const next = new URLSearchParams(searchParams);
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === undefined || value === "") {
+        next.delete(key);
+      } else {
+        next.set(key, value);
+      }
+    }
+    setSearchParams(next);
+  };
 
   return (
     <section className="page">
@@ -137,24 +169,67 @@ function ReadingList({ token }: { token: string }) {
         <h1>Reading Library</h1>
       </div>
 
+      <form
+        className="search-form"
+        onSubmit={(event) => {
+          event.preventDefault();
+          updateParams({ q: draft.trim(), offset: undefined });
+        }}
+      >
+        <label htmlFor="reading-search">Search readings</label>
+        <input
+          id="reading-search"
+          type="search"
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          placeholder="title, url, tldr, summary"
+        />
+        <button type="submit">Search</button>
+      </form>
+
+      {tag !== "" ? (
+        <div className="active-filters" aria-label="Active filters">
+          <button
+            type="button"
+            className="active-tag"
+            aria-label={`Clear tag ${tag}`}
+            onClick={() => updateParams({ tag: undefined, offset: undefined })}
+          >
+            Tag: {tag} ×
+          </button>
+        </div>
+      ) : null}
+
       {query.isLoading ? <StatusMessage>Loading readings</StatusMessage> : null}
       {query.isError ? <ErrorState error={query.error} /> : null}
       {query.isSuccess && query.data.readings.length === 0 ? (
-        <StatusMessage>No readings yet</StatusMessage>
+        <StatusMessage>{emptyMessage(q, tag)}</StatusMessage>
       ) : null}
       {query.isSuccess && query.data.readings.length > 0 ? (
         <>
           <div className="reading-list">
             {query.data.readings.map((reading) => (
-              <ReadingListItem key={reading.id} reading={reading} />
+              <ReadingListItem
+                key={reading.id}
+                reading={reading}
+                onSelectTag={(selected) => updateParams({ tag: selected, offset: undefined })}
+              />
             ))}
           </div>
           <div className="pager">
-            <button type="button" disabled={offset === 0} onClick={() => setOffset(Math.max(0, offset - pageSize))}>
+            <button
+              type="button"
+              disabled={offset === 0}
+              onClick={() => updateParams({ offset: nextOffsetParam(offset - pageSize) })}
+            >
               Previous
             </button>
             <span>Page {Math.floor(offset / pageSize) + 1}</span>
-            <button type="button" disabled={!query.data.has_more} onClick={() => setOffset(offset + pageSize)}>
+            <button
+              type="button"
+              disabled={!query.data.has_more}
+              onClick={() => updateParams({ offset: nextOffsetParam(offset + pageSize) })}
+            >
               Next
             </button>
           </div>
@@ -164,13 +239,36 @@ function ReadingList({ token }: { token: string }) {
   );
 }
 
-function ReadingListItem({ reading }: { reading: Reading }) {
+function parseOffset(raw: string | null): number {
+  if (raw === null) return 0;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+function nextOffsetParam(value: number): string | undefined {
+  return value <= 0 ? undefined : String(value);
+}
+
+function emptyMessage(q: string, tag: string): string {
+  if (q !== "" || tag !== "") {
+    return "No readings match your filters";
+  }
+  return "No readings yet";
+}
+
+function ReadingListItem({
+  reading,
+  onSelectTag
+}: {
+  reading: Reading;
+  onSelectTag: (tag: string) => void;
+}) {
   return (
     <article className="reading-row">
       <div className="reading-row-main">
         <Link to={`/readings/${reading.id}`}>{reading.title || reading.url}</Link>
         <p>{reading.tldr}</p>
-        <TagList tags={reading.tags} />
+        <TagList tags={reading.tags} onSelect={onSelectTag} />
       </div>
       <div className="reading-row-meta">
         <span>{reading.novelty_verdict || "unclassified"}</span>
@@ -228,19 +326,88 @@ function ReadingDetail({ token }: { token: string }) {
         <EntityGroup label="People" values={reading.people} />
         <EntityGroup label="Organizations" values={reading.orgs} />
       </section>
-      {reading.connections.length > 0 ? (
-        <section className="detail-section">
-          <h2>Connections</h2>
-          <ul className="connections">
-            {reading.connections.map((connection) => (
-              <li key={`${connection.reading_id}-${connection.reason}`}>
-                <span>{connection.reading_id}</span>
-                <p>{connection.reason}</p>
-              </li>
-            ))}
-          </ul>
-        </section>
-      ) : null}
+      <RelatedReadingsPanel related={reading.related} />
+      <OriginatingTaskPanel task={reading.originating_task ?? null} />
+    </section>
+  );
+}
+
+function OriginatingTaskPanel({ task }: { task: OriginatingTask | null }) {
+  return (
+    <section className="detail-section originating-task">
+      <h2>Originating Task</h2>
+      {task === null ? (
+        <p className="empty-state">Originating task is unavailable.</p>
+      ) : (
+        <dl className="task-meta">
+          <div>
+            <dt>ID</dt>
+            <dd>{task.id}</dd>
+          </div>
+          <div>
+            <dt>Status</dt>
+            <dd className={`task-status status-${task.status}`}>{task.status}</dd>
+          </div>
+          <div>
+            <dt>Mode</dt>
+            <dd>{task.task_mode}</dd>
+          </div>
+          {task.error !== "" ? (
+            <div>
+              <dt>Error</dt>
+              <dd className="task-error">{task.error}</dd>
+            </div>
+          ) : null}
+          <div>
+            <dt>Links</dt>
+            <dd>
+              <ul className="task-links">
+                {task.output_url !== "" ? (
+                  <li>
+                    <a href={task.output_url} rel="noreferrer" target="_blank">
+                      Agent output
+                    </a>
+                  </li>
+                ) : null}
+                <li>
+                  <a href={`/api/v1/tasks/${task.id}/logs`} rel="noreferrer" target="_blank">
+                    Container logs
+                  </a>
+                </li>
+                {task.pr_url !== "" ? (
+                  <li>
+                    <a href={task.pr_url} rel="noreferrer" target="_blank">
+                      Pull request
+                    </a>
+                  </li>
+                ) : null}
+              </ul>
+            </dd>
+          </div>
+        </dl>
+      )}
+    </section>
+  );
+}
+
+function RelatedReadingsPanel({ related }: { related: RelatedReading[] }) {
+  return (
+    <section className="detail-section related-readings">
+      <h2>Related Readings</h2>
+      {related.length === 0 ? (
+        <p className="empty-state">No related readings yet</p>
+      ) : (
+        <ul className="related-list">
+          {related.map((entry) => (
+            <li key={entry.reading_id} className="related-item">
+              <Link to={`/readings/${entry.reading_id}`}>{entry.title || entry.url}</Link>
+              {entry.tldr ? <p className="related-tldr">{entry.tldr}</p> : null}
+              <p className="related-url">{entry.url}</p>
+              <p className="related-reason">{entry.reason}</p>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }
@@ -254,15 +421,27 @@ function EntityGroup({ label, values }: { label: string; values: string[] }) {
   );
 }
 
-function TagList({ tags }: { tags: string[] }) {
+function TagList({ tags, onSelect }: { tags: string[]; onSelect?: (tag: string) => void }) {
   if (tags.length === 0) {
     return null;
   }
   return (
     <div className="tags">
-      {tags.map((tag) => (
-        <span key={tag}>{tag}</span>
-      ))}
+      {tags.map((tag) =>
+        onSelect ? (
+          <button
+            key={tag}
+            type="button"
+            className="tag-chip"
+            aria-label={`Filter by tag ${tag}`}
+            onClick={() => onSelect(tag)}
+          >
+            {tag}
+          </button>
+        ) : (
+          <span key={tag}>{tag}</span>
+        )
+      )}
     </div>
   );
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -3,6 +3,9 @@ import createClient from "openapi-fetch";
 import type { components, paths } from "./generated/api";
 
 export type Reading = components["schemas"]["Reading"];
+export type ReadingDetail = components["schemas"]["ReadingDetail"];
+export type RelatedReading = components["schemas"]["RelatedReading"];
+export type OriginatingTask = components["schemas"]["OriginatingTaskInfo"];
 export type ReadingPage = components["schemas"]["ReadingPage"];
 
 export const tokenStorageKey = "backlite.bearerToken";
@@ -40,9 +43,26 @@ function errorMessage(error: unknown, fallback: string) {
   return fallback;
 }
 
-export async function listReadings(token: string, limit: number, offset: number): Promise<ReadingPage> {
+export type ListReadingsParams = {
+  limit: number;
+  offset: number;
+  q?: string;
+  tag?: string;
+};
+
+export async function listReadings(token: string, params: ListReadingsParams): Promise<ReadingPage> {
+  const query: Record<string, string | number> = {
+    limit: params.limit,
+    offset: params.offset
+  };
+  if (params.q && params.q !== "") {
+    query.q = params.q;
+  }
+  if (params.tag && params.tag !== "") {
+    query.tag = params.tag;
+  }
   const { data, error, response } = await clientFor(token).GET("/api/v1/readings", {
-    params: { query: { limit, offset } }
+    params: { query }
   });
   if (!response.ok || !data) {
     throw new ApiError(response.status, errorMessage(error, "failed to list readings"));
@@ -50,7 +70,7 @@ export async function listReadings(token: string, limit: number, offset: number)
   return data.data;
 }
 
-export async function getReading(token: string, id: string): Promise<Reading> {
+export async function getReading(token: string, id: string): Promise<ReadingDetail> {
   const { data, error, response } = await clientFor(token).GET("/api/v1/readings/{id}", {
     params: { path: { id } }
   });

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -73,7 +73,7 @@ export interface paths {
         };
         /**
          * List saved readings
-         * @description Returns saved reading results newest-first with offset pagination. Requires bearer authentication when API keys are configured.
+         * @description Returns saved reading results newest-first with offset pagination. Optionally filtered by a free-text query (`q`) that matches against title, url, tldr, and summary. Requires bearer authentication when API keys are configured.
          */
         get: operations["listReadings"];
         put?: never;
@@ -283,7 +283,7 @@ export interface components {
             data: components["schemas"]["ReadingPage"];
         };
         ReadingEnvelope: {
-            data: components["schemas"]["Reading"];
+            data: components["schemas"]["ReadingDetail"];
         };
         ReadingPage: {
             readings: components["schemas"]["Reading"][];
@@ -581,6 +581,36 @@ export interface components {
             /** @example Covers the same deployment pattern. */
             reason: string;
         };
+        /** @description Reading detail used by the reading-library SPA. Extends Reading with connections resolved against the readings table (related[]) and a snapshot of the task that produced the reading. */
+        ReadingDetail: components["schemas"]["Reading"] & {
+            related: components["schemas"]["RelatedReading"][];
+            originating_task?: components["schemas"]["OriginatingTaskInfo"];
+        };
+        /** @description A connection that has been resolved to the linked reading's display fields. */
+        RelatedReading: {
+            reading_id: string;
+            reason: string;
+            title: string;
+            tldr: string;
+            /** Format: uri */
+            url: string;
+            novelty_verdict: string;
+        };
+        /** @description Snapshot of the task that produced the reading. */
+        OriginatingTaskInfo: {
+            id: string;
+            status: components["schemas"]["TaskStatus"];
+            /** @enum {string} */
+            task_mode: "auto" | "code" | "review" | "read";
+            repo_url: string;
+            pr_url: string;
+            output_url: string;
+            error: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            completed_at?: string;
+        };
     };
     responses: never;
     parameters: never;
@@ -693,6 +723,10 @@ export interface operations {
                 limit?: number;
                 /** @description Number of readings to skip for pagination */
                 offset?: number;
+                /** @description Free-text query matched case-insensitively against title, url, tldr, and summary. */
+                q?: string;
+                /** @description Restrict results to readings whose tags array contains this tag (case-insensitive exact match). */
+                tag?: string;
             };
             header?: never;
             path?: never;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -203,13 +203,172 @@ h2 {
   margin-top: 10px;
 }
 
-.tags span {
+.tags span,
+.tags .tag-chip {
   background: #eef2f6;
   border: 1px solid #d5dde7;
   border-radius: 999px;
   color: #435164;
   font-size: 0.82rem;
   padding: 4px 8px;
+}
+
+.tag-chip {
+  cursor: pointer;
+  font: inherit;
+}
+
+.tag-chip:hover {
+  background: #d8e1ec;
+}
+
+.search-form {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.search-form label {
+  color: #526071;
+  font-size: 0.85rem;
+}
+
+.search-form input {
+  border: 1px solid #c9d2dd;
+  border-radius: 6px;
+  flex: 1;
+  min-width: 0;
+  padding: 8px 10px;
+}
+
+.search-form button {
+  background: #146c60;
+  border: 0;
+  border-radius: 6px;
+  color: #ffffff;
+  cursor: pointer;
+  padding: 8px 12px;
+}
+
+.active-filters {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.active-tag {
+  background: #fff5d6;
+  border: 1px solid #e6cc6f;
+  border-radius: 999px;
+  color: #6a5212;
+  cursor: pointer;
+  font-size: 0.85rem;
+  padding: 4px 10px;
+}
+
+.active-tag:hover {
+  background: #fde8a3;
+}
+
+.related-readings .related-list {
+  display: grid;
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.related-item {
+  border-left: 3px solid #b9dacf;
+  padding-left: 10px;
+}
+
+.related-item a {
+  font-weight: 700;
+}
+
+.related-tldr {
+  margin-top: 4px;
+}
+
+.related-url {
+  color: #6f7c8d;
+  font-size: 0.85rem;
+  overflow-wrap: anywhere;
+}
+
+.related-reason {
+  color: #4d5a69;
+  font-style: italic;
+  margin-top: 4px;
+}
+
+.empty-state {
+  color: #6f7c8d;
+  font-style: italic;
+}
+
+.task-meta {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+}
+
+.task-meta > div {
+  display: grid;
+  grid-template-columns: 90px minmax(0, 1fr);
+  gap: 12px;
+}
+
+.task-meta dt {
+  color: #6f7c8d;
+  font-size: 0.85rem;
+}
+
+.task-meta dd {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.task-status {
+  border-radius: 999px;
+  display: inline-block;
+  font-size: 0.85rem;
+  padding: 2px 8px;
+}
+
+.task-status.status-completed {
+  background: #e8f3ef;
+  color: #14574e;
+}
+
+.task-status.status-failed,
+.task-status.status-cancelled {
+  background: #fde8e8;
+  color: #952424;
+}
+
+.task-status.status-running,
+.task-status.status-provisioning,
+.task-status.status-pending,
+.task-status.status-recovering,
+.task-status.status-interrupted {
+  background: #e6efff;
+  color: #1f4593;
+}
+
+.task-error {
+  color: #952424;
+}
+
+.task-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
 }
 
 .pager {


### PR DESCRIPTION
Closes #67.

Implements slice 2 of the reading-library PRD: richer discovery on top of the MVP. Built TDD across 7 vertical slices (B1–B3 backend, F1–F4 frontend) — each a one-test → minimal-impl loop.

## Backend (`internal/api`, `internal/store`, `api/openapi.yaml`)

- `GET /api/v1/readings`
  - `?q=<text>` — case-insensitive substring across `title`, `url`, `tldr`, `summary` (`LIKE`).
  - `?tag=<tag>` — case-insensitive exact match against the JSON `tags` array via `json_each(readings.tags)`.
  - `q` and `tag` compose with each other and existing pagination.
- `GET /api/v1/readings/{id}` now returns a `ReadingDetail`:
  - `related[]` — each connection resolved against the readings table to include `title`, `tldr`, `url`, `novelty_verdict` plus the original `reason`. Dangling references (target reading no longer exists) are dropped so the UI never has to render an entry without enough context to act on.
  - `originating_task` — snapshot of the task that produced the reading (`id`, `status`, `task_mode`, `repo_url`, `pr_url`, `output_url`, `error`, `created_at`, `completed_at`). `null` when the parent task isn't resolvable, so the UI can render an unavailable state.
- OpenAPI 3 spec: new `q` and `tag` query params on `listReadings`; new `ReadingDetail`, `RelatedReading`, and `OriginatingTaskInfo` schemas wired into `ReadingEnvelope`. The existing `openapi_validate_test.go` validates every test response against the spec.

## Web (`web/src`)

- Search form — input hydrates from `?q=` and submits update the URL via `useSearchParams`; TanStack Query rekey'd on `q` so refetch is automatic. New empty-state copy when filters return zero results.
- Tag chips — list-row tag pills are now buttons; clicking sets `?tag=`. Active-tag pill above the list clears the filter on click. Detail-view entity groups stay display-only.
- Related Readings panel — populated from `related[]` with link to each related reading plus its TL;DR/URL/reason; empty state ("No related readings yet") when the array is empty.
- Originating Task panel — task ID/status/mode plus links to Agent output (`/api/v1/tasks/{id}/output`), Container logs (`/api/v1/tasks/{id}/logs`), and the PR if any. Renders "Originating task is unavailable" when `originating_task === null`.
- API client (`api.ts`) — `listReadings` now takes a `ListReadingsParams` object (`limit`/`offset`/`q`/`tag`); `getReading` returns the new `ReadingDetail`. Generated types refreshed.

## Tests

5 new Go tests in `internal/api/handlers_test.go`:
- `TestListReadings_FiltersByQueryAcrossSearchableFields`
- `TestListReadings_FiltersByTagAndCombinesWithQuery`
- `TestGetReading_IncludesResolvedRelatedAndOriginatingTask`
- `TestGetReading_NoConnectionsAndAllDanglingReturnsEmptyRelated`

5 new Vitest specs in `web/src/App.test.tsx`:
- search submit puts `q` on the request URL
- URL `?q=` hydrates the search input
- tag-chip click filters with `?tag=`; active-tag clear removes it
- Related Readings panel renders title/tldr/url/reason; empty state when none
- Originating Task panel renders status + output link; unavailable copy when null

## Test plan
- [x] `go test -tags nocontainers ./...` (all packages green)
- [x] `go test ./internal/api/` (default tag — runs `openapi_validate_test.go` against the new spec)
- [x] `cd web && npx vitest run` (12/12 specs)
- [x] `cd web && npm run build` (`tsc -b && vite build`)
- [x] Browser smoke test of `/?q=…`, tag chip click, and detail page on a running server (not exercised this session — recommended before merge)