### PR TITLE
feat: markdown ingestion for read mode — slice 1 (#77)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1012,6 +1012,13 @@ components:
         container_id:
           type: string
           example: "abc123def456"
+        inline_content_sha256:
+          type: string
+          description: |
+            Set on read-mode tasks whose source is a markdown body persisted to
+            disk under <DataDir>/ingest/<sha>.md instead of a URL fetched at run
+            time. The task's prompt for such tasks is "markdown://<sha>".
+          example: "9caaf00e460351844ec0267af19e123c624aad0a34794e205fe3d02053cd5c06"
         retry_count:
           type: integer
           minimum: 0
@@ -1145,6 +1152,15 @@ components:
           description: Additional environment variables to set in the agent container.
           example:
             CUSTOM_SETTING: "value"
+        inline_content:
+          type: string
+          nullable: true
+          description: |
+            Optional raw markdown body. When set, task_mode must be "read", the
+            prompt must not contain a URL, and the value must be non-empty. The
+            server persists the body to a content-addressed file under the data
+            directory and rewrites the task's prompt to "markdown://<sha256>".
+          example: "# Project notes\n\nbody"
 
     Reading:
       type: object

--- a/docker/reader/fetch-and-extract.sh
+++ b/docker/reader/fetch-and-extract.sh
@@ -12,10 +12,6 @@ set -euo pipefail
 # of the content-capture feature only ships the HTML happy path; richer
 # failure-status semantics land in a follow-up slice.
 
-if [ -z "${URL:-}" ]; then
-    echo "ERROR: URL is required" >&2
-    exit 1
-fi
 WORKSPACE="${WORKSPACE:-/home/agent/workspace}"
 mkdir -p "$WORKSPACE"
 
@@ -25,6 +21,47 @@ RAW_PATH="$WORKSPACE/raw.html"
 EXTRACTED_PATH="$WORKSPACE/extracted.md"
 SIDECAR_PATH="$WORKSPACE/content.json"
 HEADERS_PATH="$WORKSPACE/.headers.txt"
+
+# --- Inline-content short-circuit ---
+# When the orchestrator bind-mounts a markdown file into the container and
+# sets INLINE_CONTENT_PATH, the URL fetch + extraction pipeline is skipped:
+# the file is the extracted markdown.
+if [ -n "${INLINE_CONTENT_PATH:-}" ]; then
+    if [ ! -f "$INLINE_CONTENT_PATH" ]; then
+        echo "ERROR: INLINE_CONTENT_PATH=$INLINE_CONTENT_PATH not found" >&2
+        exit 1
+    fi
+    cp "$INLINE_CONTENT_PATH" "$EXTRACTED_PATH"
+
+    INLINE_BYTES=$(wc -c < "$EXTRACTED_PATH" | tr -d ' ')
+    if command -v sha256sum >/dev/null 2>&1; then
+        INLINE_SHA=$(sha256sum "$EXTRACTED_PATH" | awk '{print $1}')
+    else
+        INLINE_SHA=$(shasum -a 256 "$EXTRACTED_PATH" | awk '{print $1}')
+    fi
+    INLINE_FETCHED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    jq -n \
+        --arg ct "text/markdown" \
+        --arg status "captured" \
+        --argjson cb "$INLINE_BYTES" \
+        --argjson eb "$INLINE_BYTES" \
+        --arg sha "$INLINE_SHA" \
+        --arg fetched "$INLINE_FETCHED_AT" '{
+            content_type: $ct,
+            content_status: $status,
+            content_bytes: $cb,
+            extracted_bytes: $eb,
+            content_sha256: $sha,
+            fetched_at: $fetched
+        }' > "$SIDECAR_PATH"
+    exit 0
+fi
+
+if [ -z "${URL:-}" ]; then
+    echo "ERROR: URL is required" >&2
+    exit 1
+fi
 
 # --- Fetch ---
 # -L: follow redirects. -sS: silent but show errors. -A: identify ourselves.

--- a/docker/reader/test_fetch_and_extract.sh
+++ b/docker/reader/test_fetch_and_extract.sh
@@ -121,4 +121,57 @@ if WORKSPACE="$TMPROOT/empty" EXTRACT_CMD="$EXTRACT_CMD_STUB" bash "$SCRIPT" >/d
     fail "expected non-zero exit when URL is empty"
 fi
 
+# --- INLINE_CONTENT_PATH short-circuit ---
+INLINE_DIR="$TMPROOT/inline"
+INLINE_WS="$TMPROOT/inline-ws"
+mkdir -p "$INLINE_DIR" "$INLINE_WS"
+
+INLINE_FILE="$INLINE_DIR/note.md"
+cat > "$INLINE_FILE" <<'MARKDOWN'
+# Inline Test Note
+
+Body of the inline-ingested markdown file.
+MARKDOWN
+
+# Run with INLINE_CONTENT_PATH set, no URL.
+unset URL
+INLINE_CONTENT_PATH="$INLINE_FILE" \
+WORKSPACE="$INLINE_WS" \
+EXTRACT_CMD="$EXTRACT_CMD_STUB" \
+    bash "$SCRIPT" || fail "fetch-and-extract.sh inline branch exited non-zero"
+
+# extracted.md must be byte-equal to the input file.
+if ! cmp -s "$INLINE_FILE" "$INLINE_WS/extracted.md"; then
+    fail "extracted.md not byte-equal to INLINE_CONTENT_PATH input"
+fi
+
+# raw.html must NOT exist for the inline branch.
+if [ -e "$INLINE_WS/raw.html" ]; then
+    fail "raw.html should not exist for inline-content branch"
+fi
+
+# content.json sidecar — same fields as URL branch but content_type=text/markdown.
+inline_sidecar="$INLINE_WS/content.json"
+if [ ! -f "$inline_sidecar" ]; then
+    fail "content.json missing for inline branch"
+fi
+if ! jq -e '.content_status == "captured"' "$inline_sidecar" >/dev/null; then
+    fail "inline content.json: content_status != captured ($(cat "$inline_sidecar"))"
+fi
+if ! jq -e '.content_type == "text/markdown"' "$inline_sidecar" >/dev/null; then
+    fail "inline content.json: content_type != text/markdown ($(cat "$inline_sidecar"))"
+fi
+if ! jq -e '.content_bytes > 0' "$inline_sidecar" >/dev/null; then
+    fail "inline content.json: content_bytes not positive ($(cat "$inline_sidecar"))"
+fi
+if ! jq -e '.extracted_bytes > 0' "$inline_sidecar" >/dev/null; then
+    fail "inline content.json: extracted_bytes not positive ($(cat "$inline_sidecar"))"
+fi
+if ! jq -e '.content_sha256 | test("^[0-9a-f]{64}$")' "$inline_sidecar" >/dev/null; then
+    fail "inline content.json: content_sha256 not a hex sha256 ($(cat "$inline_sidecar"))"
+fi
+if ! jq -e '.fetched_at | test("^[0-9]{4}-")' "$inline_sidecar" >/dev/null; then
+    fail "inline content.json: fetched_at not RFC3339-ish ($(cat "$inline_sidecar"))"
+fi
+
 echo "ok"

--- a/internal/api/task_creator.go
+++ b/internal/api/task_creator.go
@@ -16,9 +16,10 @@ import (
 	"github.com/brian-bell/backlite/internal/store"
 )
 
-// urlBearingPrompt matches a prompt whose first non-whitespace token is an
-// http(s) URL. Used to reject inline_content paired with a URL-style prompt
-// (the two source paths are exclusive).
+// urlBearingPrompt matches a prompt that contains an http(s) URL anywhere.
+// Used to reject inline_content paired with a URL-bearing prompt — the two
+// source paths are exclusive, and slice 1 takes the conservative stance of
+// flagging any URL occurrence rather than only a leading-token URL.
 var urlBearingPrompt = regexp.MustCompile(`(?i)https?://`)
 
 // ErrStoreFailure is returned when the store fails to persist a task.

--- a/internal/api/task_creator.go
+++ b/internal/api/task_creator.go
@@ -4,15 +4,22 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"time"
 
 	"github.com/oklog/ulid/v2"
 
 	"github.com/brian-bell/backlite/internal/config"
+	"github.com/brian-bell/backlite/internal/ingest"
 	"github.com/brian-bell/backlite/internal/models"
 	"github.com/brian-bell/backlite/internal/notify"
 	"github.com/brian-bell/backlite/internal/store"
 )
+
+// urlBearingPrompt matches a prompt whose first non-whitespace token is an
+// http(s) URL. Used to reject inline_content paired with a URL-style prompt
+// (the two source paths are exclusive).
+var urlBearingPrompt = regexp.MustCompile(`(?i)https?://`)
 
 // ErrStoreFailure is returned when the store fails to persist a task.
 // Callers can use errors.Is(err, ErrStoreFailure) to distinguish store
@@ -29,6 +36,11 @@ func NewTask(ctx context.Context, req *models.CreateTaskRequest, s store.Store, 
 
 	if req.TaskMode != nil && *req.TaskMode == models.TaskModeRead {
 		return NewReadTask(ctx, req, s, cfg, bus)
+	}
+
+	// inline_content is exclusive to read-mode tasks.
+	if req.InlineContent != nil {
+		return nil, fmt.Errorf("inline_content is only valid for read-mode tasks (set task_mode=\"read\")")
 	}
 
 	now := time.Now().UTC()
@@ -91,26 +103,42 @@ func NewReadTask(ctx context.Context, req *models.CreateTaskRequest, s store.Sto
 		return nil, fmt.Errorf("reading mode is not configured on this server (BACKFLOW_READER_IMAGE is not set)")
 	}
 
+	if req.InlineContent != nil && urlBearingPrompt.MatchString(req.Prompt) {
+		return nil, fmt.Errorf("inline_content cannot be combined with a URL-bearing prompt; pick one source or the other")
+	}
+
 	now := time.Now().UTC()
 
+	prompt := req.Prompt
+	var inlineSHA string
+	if req.InlineContent != nil {
+		sha, _, err := ingest.Write(cfg.DataDir, []byte(*req.InlineContent))
+		if err != nil {
+			return nil, fmt.Errorf("persist inline_content: %w", err)
+		}
+		inlineSHA = sha
+		prompt = "markdown://" + sha
+	}
+
 	task := &models.Task{
-		ID:            "bf_" + ulid.Make().String(),
-		Status:        models.TaskStatusPending,
-		TaskMode:      models.TaskModeRead,
-		Harness:       models.Harness(req.Harness),
-		Prompt:        req.Prompt,
-		Context:       req.Context,
-		Model:         req.Model,
-		Effort:        req.Effort,
-		Force:         req.Force != nil && *req.Force,
-		MaxBudgetUSD:  req.MaxBudgetUSD,
-		MaxRuntimeSec: req.MaxRuntimeSec,
-		MaxTurns:      req.MaxTurns,
-		AllowedTools:  req.AllowedTools,
-		ClaudeMD:      req.ClaudeMD,
-		EnvVars:       req.EnvVars,
-		CreatedAt:     now,
-		UpdatedAt:     now,
+		ID:                  "bf_" + ulid.Make().String(),
+		Status:              models.TaskStatusPending,
+		TaskMode:            models.TaskModeRead,
+		Harness:             models.Harness(req.Harness),
+		Prompt:              prompt,
+		InlineContentSHA256: inlineSHA,
+		Context:             req.Context,
+		Model:               req.Model,
+		Effort:              req.Effort,
+		Force:               req.Force != nil && *req.Force,
+		MaxBudgetUSD:        req.MaxBudgetUSD,
+		MaxRuntimeSec:       req.MaxRuntimeSec,
+		MaxTurns:            req.MaxTurns,
+		AllowedTools:        req.AllowedTools,
+		ClaudeMD:            req.ClaudeMD,
+		EnvVars:             req.EnvVars,
+		CreatedAt:           now,
+		UpdatedAt:           now,
 	}
 
 	cfg.TaskDefaults(models.TaskModeRead).Apply(task, &config.BoolOverrides{

--- a/internal/api/task_creator_test.go
+++ b/internal/api/task_creator_test.go
@@ -2,8 +2,12 @@ package api
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/brian-bell/backlite/internal/config"
@@ -352,4 +356,144 @@ func TestNewReadTask_IgnoresPRFields(t *testing.T) {
 	if task.SelfReview {
 		t.Error("SelfReview = true, want false (ignored for read mode)")
 	}
+}
+
+func TestNewTask_RejectsInlineContentOnAutoMode(t *testing.T) {
+	cfg := &config.Config{
+		AgentImage: "backlite-agent",
+	}
+	s := &mockStore{}
+	body := "# title\nbody\n"
+	req := &models.CreateTaskRequest{
+		Prompt:        "Fix the bug",
+		InlineContent: &body,
+	}
+
+	_, err := NewTask(context.Background(), req, s, cfg, nil)
+	if err == nil {
+		t.Fatal("expected error rejecting inline_content on auto mode; got nil")
+	}
+	if errors.Is(err, ErrStoreFailure) {
+		t.Errorf("error should be a validation error, not ErrStoreFailure: %v", err)
+	}
+	if s.createCalls != 0 {
+		t.Errorf("CreateTask should not be called on validation failure; got %d calls", s.createCalls)
+	}
+}
+
+func TestNewReadTask_RejectsInlineContentWithURLPrompt(t *testing.T) {
+	cfg := readTestConfig()
+	s := &mockStore{}
+	body := "# title\nbody\n"
+	mode := models.TaskModeRead
+	req := &models.CreateTaskRequest{
+		Prompt:        "https://example.com/post",
+		TaskMode:      &mode,
+		InlineContent: &body,
+	}
+
+	_, err := NewReadTask(context.Background(), req, s, cfg, nil)
+	if err == nil {
+		t.Fatal("expected error rejecting URL prompt with inline_content; got nil")
+	}
+	if errors.Is(err, ErrStoreFailure) {
+		t.Errorf("error should be a validation error, not ErrStoreFailure: %v", err)
+	}
+	if s.createCalls != 0 {
+		t.Errorf("CreateTask should not be called; got %d calls", s.createCalls)
+	}
+}
+
+func TestNewReadTask_AllowsInlineContentWithNonURLPrompt(t *testing.T) {
+	cfg := readTestConfig()
+	cfg.DataDir = t.TempDir()
+	s := &mockStore{}
+	body := "# title\nbody\n"
+	mode := models.TaskModeRead
+	req := &models.CreateTaskRequest{
+		Prompt:        "anything",
+		TaskMode:      &mode,
+		InlineContent: &body,
+	}
+
+	// The URL guard must not fire for a non-URL prompt; the call should
+	// reach persistence and succeed against the in-memory mock store.
+	if _, err := NewReadTask(context.Background(), req, s, cfg, nil); err != nil {
+		t.Errorf("NewReadTask with non-URL prompt should succeed, got: %v", err)
+	}
+}
+
+func TestNewReadTask_WithInlineContent_WritesFileAndRewritesPrompt(t *testing.T) {
+	// Arrange: a config pointing DataDir at a tempdir, and a captured store
+	// that records what task is persisted.
+	dataDir := t.TempDir()
+	cfg := readTestConfig()
+	cfg.DataDir = dataDir
+	bus := &capturingEmitter{}
+
+	captured := &capturingStore{}
+	body := "# Title\n\nbody text\n"
+	mode := models.TaskModeRead
+	req := &models.CreateTaskRequest{
+		Prompt:        "ingest a local note",
+		TaskMode:      &mode,
+		InlineContent: &body,
+	}
+
+	// Act
+	task, err := NewReadTask(context.Background(), req, captured, cfg, bus)
+	if err != nil {
+		t.Fatalf("NewReadTask: %v", err)
+	}
+
+	// Assert: SHA matches the body, prompt rewritten, on-disk file present.
+	wantSHA := sha256Hex([]byte(body))
+	if task.InlineContentSHA256 != wantSHA {
+		t.Errorf("InlineContentSHA256 = %q, want %q", task.InlineContentSHA256, wantSHA)
+	}
+	wantPrompt := "markdown://" + wantSHA
+	if task.Prompt != wantPrompt {
+		t.Errorf("Prompt = %q, want %q", task.Prompt, wantPrompt)
+	}
+
+	wantPath := filepath.Join(dataDir, "ingest", wantSHA+".md")
+	got, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("read persisted ingest file: %v", err)
+	}
+	if string(got) != body {
+		t.Errorf("on-disk body = %q, want %q", got, body)
+	}
+
+	// Store received the rewritten task.
+	if captured.lastTask == nil {
+		t.Fatal("CreateTask was not called")
+	}
+	if captured.lastTask.Prompt != wantPrompt {
+		t.Errorf("store received Prompt = %q, want %q", captured.lastTask.Prompt, wantPrompt)
+	}
+	if captured.lastTask.InlineContentSHA256 != wantSHA {
+		t.Errorf("store received InlineContentSHA256 = %q, want %q", captured.lastTask.InlineContentSHA256, wantSHA)
+	}
+
+	// task.created event was emitted.
+	if len(bus.events) != 1 || bus.events[0].Type != notify.EventTaskCreated {
+		t.Errorf("expected one task.created event, got %+v", bus.events)
+	}
+}
+
+// capturingStore records the task last passed to CreateTask.
+type capturingStore struct {
+	mockStore
+	lastTask *models.Task
+}
+
+func (c *capturingStore) CreateTask(ctx context.Context, t *models.Task) error {
+	c.lastTask = t
+	return c.mockStore.CreateTask(ctx, t)
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
 }

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -1,0 +1,60 @@
+// Package ingest persists user-supplied content to the data dir under a
+// content-addressed path. It is the entry point for markdown bodies that
+// arrive via the API's inline_content field on read-mode tasks; once a body
+// is on disk at <DataDir>/ingest/<sha>.md the orchestrator can bind-mount
+// the file into a reader container without exposing the rest of the data
+// directory.
+package ingest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrEmptyContent is returned when Write is called with a nil or empty body.
+var ErrEmptyContent = errors.New("ingest: content is empty")
+
+// Write computes the SHA-256 of body, atomically writes it to
+// <dataDir>/ingest/<sha>.md, and returns the hex SHA and absolute path.
+//
+// The write is atomic: bytes go to a *.tmp sibling first and are renamed
+// into place. The caller is responsible for ensuring dataDir exists or is
+// creatable; this function will MkdirAll the ingest subdirectory.
+func Write(dataDir string, body []byte) (sha string, path string, err error) {
+	if len(body) == 0 {
+		return "", "", ErrEmptyContent
+	}
+	sum := sha256.Sum256(body)
+	sha = hex.EncodeToString(sum[:])
+
+	dir := filepath.Join(dataDir, "ingest")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", "", fmt.Errorf("ingest: mkdir: %w", err)
+	}
+
+	path = filepath.Join(dir, sha+".md")
+
+	tmp, err := os.CreateTemp(dir, sha+".*.tmp")
+	if err != nil {
+		return "", "", fmt.Errorf("ingest: create temp: %w", err)
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(body); err != nil {
+		tmp.Close()
+		os.Remove(tmpName)
+		return "", "", fmt.Errorf("ingest: write temp: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpName)
+		return "", "", fmt.Errorf("ingest: close temp: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		os.Remove(tmpName)
+		return "", "", fmt.Errorf("ingest: rename: %w", err)
+	}
+	return sha, path, nil
+}

--- a/internal/ingest/ingest_test.go
+++ b/internal/ingest/ingest_test.go
@@ -1,0 +1,112 @@
+package ingest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWrite_PersistsShaFile(t *testing.T) {
+	dataDir := t.TempDir()
+	body := []byte("# Hello\n\nbody text\n")
+
+	sha, path, err := Write(dataDir, body)
+	if err != nil {
+		t.Fatalf("Write returned error: %v", err)
+	}
+
+	sum := sha256.Sum256(body)
+	wantSHA := hex.EncodeToString(sum[:])
+	if sha != wantSHA {
+		t.Fatalf("sha mismatch: got %q, want %q", sha, wantSHA)
+	}
+
+	wantPath := filepath.Join(dataDir, "ingest", wantSHA+".md")
+	if path != wantPath {
+		t.Fatalf("path mismatch: got %q, want %q", path, wantPath)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read written file: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("file bytes mismatch: got %q, want %q", got, body)
+	}
+
+	// No tmp debris left in the ingest dir.
+	entries, err := os.ReadDir(filepath.Join(dataDir, "ingest"))
+	if err != nil {
+		t.Fatalf("read ingest dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Fatalf("found tmp file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestWrite_IdempotentSecondCall(t *testing.T) {
+	dataDir := t.TempDir()
+	body := []byte("# repeat\n\nidempotence test\n")
+
+	sha1, path1, err := Write(dataDir, body)
+	if err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+
+	sha2, path2, err := Write(dataDir, body)
+	if err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	if sha1 != sha2 {
+		t.Fatalf("sha differs across calls: %q vs %q", sha1, sha2)
+	}
+	if path1 != path2 {
+		t.Fatalf("path differs across calls: %q vs %q", path1, path2)
+	}
+
+	// File still has correct contents.
+	got, err := os.ReadFile(path2)
+	if err != nil {
+		t.Fatalf("read after second Write: %v", err)
+	}
+	if string(got) != string(body) {
+		t.Fatalf("contents corrupted after second Write: got %q", got)
+	}
+
+	// No tmp debris.
+	entries, err := os.ReadDir(filepath.Join(dataDir, "ingest"))
+	if err != nil {
+		t.Fatalf("read ingest dir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp") {
+			t.Fatalf("found tmp file left behind after second Write: %s", e.Name())
+		}
+	}
+}
+
+func TestWrite_RejectsEmpty(t *testing.T) {
+	dataDir := t.TempDir()
+
+	for _, body := range [][]byte{nil, {}} {
+		_, _, err := Write(dataDir, body)
+		if !errors.Is(err, ErrEmptyContent) {
+			t.Fatalf("expected ErrEmptyContent for body=%q, got %v", body, err)
+		}
+	}
+
+	// No ingest dir or its contents created on rejection.
+	entries, err := os.ReadDir(filepath.Join(dataDir, "ingest"))
+	if err == nil {
+		for _, e := range entries {
+			t.Fatalf("expected no files on empty rejection, found %s", e.Name())
+		}
+	}
+}

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -169,6 +169,7 @@ var reservedEnvVarKeys = map[string]bool{
 	"RESEND_API_KEY":        true,
 	"NOTIFY_EMAIL_FROM":     true,
 	"NOTIFY_EMAIL_TO":       true,
+	"INLINE_CONTENT_PATH":   true,
 }
 
 // containsNullByte returns true if s contains a null byte, which PostgreSQL

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -70,16 +70,21 @@ type Task struct {
 	ClaudeMD        string            `json:"claude_md,omitempty"`
 	EnvVars         map[string]string `json:"env_vars,omitempty"`
 	ContainerID     string            `json:"container_id,omitempty"`
-	RetryCount      int               `json:"retry_count"`
-	UserRetryCount  int               `json:"user_retry_count"`
-	ReadyForRetry   bool              `json:"ready_for_retry"`
-	CostUSD         float64           `json:"cost_usd,omitempty"`
-	ElapsedTimeSec  int               `json:"elapsed_time_sec,omitempty"`
-	Error           string            `json:"error,omitempty"`
-	CreatedAt       time.Time         `json:"created_at"`
-	UpdatedAt       time.Time         `json:"updated_at"`
-	StartedAt       *time.Time        `json:"started_at,omitempty"`
-	CompletedAt     *time.Time        `json:"completed_at,omitempty"`
+	// InlineContentSHA256, when non-empty, marks a read-mode task whose
+	// source is a markdown body persisted under
+	// {DataDir}/ingest/<sha>.md instead of a URL fetched at run time.
+	// Prompt for such tasks is rewritten to "markdown://<sha>".
+	InlineContentSHA256 string     `json:"inline_content_sha256,omitempty"`
+	RetryCount          int        `json:"retry_count"`
+	UserRetryCount      int        `json:"user_retry_count"`
+	ReadyForRetry       bool       `json:"ready_for_retry"`
+	CostUSD             float64    `json:"cost_usd,omitempty"`
+	ElapsedTimeSec      int        `json:"elapsed_time_sec,omitempty"`
+	Error               string     `json:"error,omitempty"`
+	CreatedAt           time.Time  `json:"created_at"`
+	UpdatedAt           time.Time  `json:"updated_at"`
+	StartedAt           *time.Time `json:"started_at,omitempty"`
+	CompletedAt         *time.Time `json:"completed_at,omitempty"`
 }
 
 // AllowedToolsJSON returns the JSON representation for DB storage.
@@ -122,6 +127,13 @@ type CreateTaskRequest struct {
 	AllowedTools    []string          `json:"allowed_tools,omitempty"`
 	ClaudeMD        string            `json:"claude_md,omitempty"`
 	EnvVars         map[string]string `json:"env_vars,omitempty"`
+	// InlineContent is an optional raw markdown body. When set on a
+	// read-mode task it is persisted to disk under a content-addressed
+	// path; the orchestrator bind-mounts that file into the reader
+	// container instead of fetching a URL. Pointer-typed so the API
+	// can distinguish "absent" from an explicitly-empty client
+	// payload (which is a validation error).
+	InlineContent *string `json:"inline_content,omitempty"`
 }
 
 // validEnvVarKey matches POSIX environment variable names: must start with a
@@ -225,6 +237,12 @@ func (r *CreateTaskRequest) Validate() error {
 		default:
 			return fmt.Errorf("task_mode must be auto or read (code and review are inferred from the prompt)")
 		}
+	}
+	if r.InlineContent != nil && *r.InlineContent == "" {
+		return fmt.Errorf("inline_content must be non-empty when set")
+	}
+	if r.InlineContent != nil && containsNullByte(*r.InlineContent) {
+		return fmt.Errorf("request contains invalid null bytes")
 	}
 	return nil
 }

--- a/internal/models/task_test.go
+++ b/internal/models/task_test.go
@@ -233,6 +233,11 @@ func TestCreateTaskRequestValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "reserved env var key INLINE_CONTENT_PATH",
+			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"INLINE_CONTENT_PATH": "/etc/passwd"}},
+			wantErr: true,
+		},
+		{
 			name:    "non-reserved env var key allowed",
 			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"MY_CUSTOM_VAR": "val"}},
 			wantErr: false,

--- a/internal/models/task_test.go
+++ b/internal/models/task_test.go
@@ -318,3 +318,86 @@ func TestTaskStatusIsTerminal(t *testing.T) {
 		}
 	}
 }
+
+func TestCreateTaskRequest_InlineContentRoundTrip(t *testing.T) {
+	body := "# Title\n\nSome markdown body.\n"
+	in := CreateTaskRequest{
+		Prompt:        "ignored",
+		InlineContent: &body,
+	}
+
+	data, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"inline_content":"# Title`) {
+		t.Errorf("missing inline_content in marshaled request: %s", data)
+	}
+
+	var got CreateTaskRequest
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.InlineContent == nil {
+		t.Fatalf("InlineContent nil after round-trip")
+	}
+	if *got.InlineContent != body {
+		t.Errorf("InlineContent = %q, want %q", *got.InlineContent, body)
+	}
+}
+
+func TestTask_InlineContentSHA256RoundTrip(t *testing.T) {
+	task := Task{ID: "bf_test", InlineContentSHA256: "deadbeef"}
+	data, err := json.Marshal(task)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"inline_content_sha256":"deadbeef"`) {
+		t.Errorf("missing inline_content_sha256 in marshaled task: %s", data)
+	}
+
+	var got Task
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if got.InlineContentSHA256 != "deadbeef" {
+		t.Errorf("InlineContentSHA256 = %q, want %q", got.InlineContentSHA256, "deadbeef")
+	}
+}
+
+func TestCreateTaskRequest_Validate_RejectsEmptyInlineContent(t *testing.T) {
+	empty := ""
+	mode := TaskModeRead
+	req := CreateTaskRequest{
+		Prompt:        "anything",
+		TaskMode:      &mode,
+		InlineContent: &empty,
+	}
+	err := req.Validate()
+	if err == nil {
+		t.Fatal("Validate accepted empty inline_content; want error")
+	}
+	if !strings.Contains(err.Error(), "inline_content") {
+		t.Errorf("error %q does not mention inline_content", err)
+	}
+}
+
+func TestCreateTaskRequest_Validate_AllowsAbsentInlineContent(t *testing.T) {
+	req := CreateTaskRequest{Prompt: "anything"}
+	if err := req.Validate(); err != nil {
+		t.Errorf("Validate rejected request without inline_content: %v", err)
+	}
+}
+
+func TestCreateTaskRequest_Validate_AllowsNonEmptyInlineContent(t *testing.T) {
+	body := "# title\nbody\n"
+	mode := TaskModeRead
+	req := CreateTaskRequest{
+		Prompt:        "anything",
+		TaskMode:      &mode,
+		InlineContent: &body,
+	}
+	if err := req.Validate(); err != nil {
+		t.Errorf("Validate rejected non-empty inline_content: %v", err)
+	}
+}

--- a/internal/orchestrator/docker/docker.go
+++ b/internal/orchestrator/docker/docker.go
@@ -113,7 +113,7 @@ func (m *Manager) GetLogs(ctx context.Context, containerID string, tail int) (st
 // envFilePath, if non-empty, adds an --env-file flag for secret env vars.
 func (m *Manager) buildRunCommand(task *models.Task, envFilePath string) string {
 	envFlags := m.buildEnvFlags(task)
-	volumeFlags := m.buildVolumeFlags()
+	volumeFlags := m.buildVolumeFlags(task)
 	networkFlags := m.buildNetworkFlags(task)
 	envFileFlag := ""
 	if envFilePath != "" {
@@ -172,6 +172,9 @@ func (m *Manager) buildEnvFlags(task *models.Task) []string {
 
 	if task.TaskMode == models.TaskModeRead {
 		flags = append(flags, envFlag("BACKFLOW_API_BASE_URL", shellEscape(m.internalAPIBaseURL())))
+		if task.InlineContentSHA256 != "" {
+			flags = append(flags, "-e INLINE_CONTENT_PATH=/workspace/inline.md")
+		}
 	}
 
 	for k, v := range task.EnvVars {
@@ -234,8 +237,14 @@ func writeEnvFile(pairs []string) (string, error) {
 }
 
 // buildVolumeFlags returns volume flags for the docker run command.
-// Currently returns empty; reserved for future use.
-func (m *Manager) buildVolumeFlags() string {
+// For read-mode tasks with inline-content sourcing, mounts the persisted
+// markdown file read-only at /workspace/inline.md so the reader container's
+// fetch step can short-circuit on the local file.
+func (m *Manager) buildVolumeFlags(task *models.Task) string {
+	if task.TaskMode == models.TaskModeRead && task.InlineContentSHA256 != "" {
+		host := fmt.Sprintf("%s/ingest/%s.md", m.config.DataDir, task.InlineContentSHA256)
+		return fmt.Sprintf("-v %s:/workspace/inline.md:ro", host)
+	}
 	return ""
 }
 

--- a/internal/orchestrator/docker/docker_test.go
+++ b/internal/orchestrator/docker/docker_test.go
@@ -534,3 +534,84 @@ func TestIsHexString(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildRunCommand_ReadModeWithInlineContent(t *testing.T) {
+	cfg := &config.Config{
+		ContainerCPUs:  2,
+		ContainerMemGB: 8,
+		AgentImage:     "backlite-agent",
+		ReaderImage:    "backlite-reader:v1",
+		DataDir:        "/data",
+	}
+	dm := NewManager(cfg)
+
+	task := &models.Task{
+		ID:                  "bf_INLINE001",
+		TaskMode:            models.TaskModeRead,
+		Prompt:              "markdown://abc123",
+		InlineContentSHA256: "abc123",
+		AgentImage:          "backlite-reader:v1",
+	}
+
+	cmd := dm.buildRunCommand(task, "")
+
+	if !strings.Contains(cmd, "-v /data/ingest/abc123.md:/workspace/inline.md:ro") {
+		t.Errorf("command missing inline-content bind-mount, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, "-e INLINE_CONTENT_PATH=/workspace/inline.md") {
+		t.Errorf("command missing INLINE_CONTENT_PATH env var, got: %s", cmd)
+	}
+}
+
+func TestBuildRunCommand_ReadModeNoInlineContentNoMount(t *testing.T) {
+	cfg := &config.Config{
+		ContainerCPUs:  2,
+		ContainerMemGB: 8,
+		AgentImage:     "backlite-agent",
+		ReaderImage:    "backlite-reader:v1",
+		DataDir:        "/data",
+	}
+	dm := NewManager(cfg)
+
+	task := &models.Task{
+		ID:         "bf_URL001",
+		TaskMode:   models.TaskModeRead,
+		Prompt:     "https://example.com/post",
+		AgentImage: "backlite-reader:v1",
+	}
+
+	cmd := dm.buildRunCommand(task, "")
+
+	if strings.Contains(cmd, "/workspace/inline.md") {
+		t.Errorf("URL-source read task should not bind-mount inline.md, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "INLINE_CONTENT_PATH") {
+		t.Errorf("URL-source read task should not set INLINE_CONTENT_PATH, got: %s", cmd)
+	}
+}
+
+func TestBuildRunCommand_NonReadModeNoInlineContent(t *testing.T) {
+	cfg := &config.Config{
+		ContainerCPUs:  2,
+		ContainerMemGB: 8,
+		AgentImage:     "backlite-agent",
+		DataDir:        "/data",
+	}
+	dm := NewManager(cfg)
+
+	// Defensive: even if a code-mode task somehow has InlineContentSHA256 set
+	// (it shouldn't reach here through the API), the command should still
+	// not include the read-only mount or env var.
+	task := &models.Task{
+		ID:                  "bf_CODE001",
+		TaskMode:            models.TaskModeCode,
+		InlineContentSHA256: "abc",
+	}
+	cmd := dm.buildRunCommand(task, "")
+	if strings.Contains(cmd, "INLINE_CONTENT_PATH") {
+		t.Errorf("non-read task should not set INLINE_CONTENT_PATH, got: %s", cmd)
+	}
+	if strings.Contains(cmd, "/workspace/inline.md") {
+		t.Errorf("non-read task should not bind-mount inline.md, got: %s", cmd)
+	}
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -89,7 +89,7 @@ const taskColumns = `id, status, task_mode, harness, repo_url, branch, target_br
 	create_pr, self_review, save_agent_output, pr_title, pr_body, pr_url, output_url,
 	allowed_tools, claude_md, env_vars,
 	container_id, retry_count, user_retry_count, cost_usd, elapsed_time_sec, error,
-	ready_for_retry, agent_image, force, parent_task_id,
+	ready_for_retry, agent_image, force, parent_task_id, inline_content_sha256,
 	created_at, updated_at, started_at, completed_at`
 
 func (s *SQLiteStore) CreateTask(ctx context.Context, task *models.Task) error {
@@ -110,7 +110,7 @@ func (s *SQLiteStore) CreateTask(ctx context.Context, task *models.Task) error {
 			create_pr, self_review, save_agent_output, pr_title, pr_body, pr_url, output_url,
 			allowed_tools, claude_md, env_vars,
 			container_id, retry_count, user_retry_count, cost_usd, elapsed_time_sec, error,
-			ready_for_retry, agent_image, force, parent_task_id,
+			ready_for_retry, agent_image, force, parent_task_id, inline_content_sha256,
 			created_at, updated_at, started_at, completed_at
 		) VALUES (
 			?, ?, ?, ?, ?, ?, ?,
@@ -119,7 +119,7 @@ func (s *SQLiteStore) CreateTask(ctx context.Context, task *models.Task) error {
 			?, ?, ?, ?, ?, ?, ?,
 			?, ?, ?,
 			?, ?, ?, ?, ?, ?,
-			?, ?, ?, ?,
+			?, ?, ?, ?, ?,
 			?, ?, ?, ?
 		)`,
 		task.ID, task.Status, task.TaskMode, task.Harness, task.RepoURL, task.Branch, task.TargetBranch,
@@ -129,7 +129,7 @@ func (s *SQLiteStore) CreateTask(ctx context.Context, task *models.Task) error {
 		task.PRTitle, task.PRBody, task.PRURL, task.OutputURL,
 		allowedTools, task.ClaudeMD, envVars,
 		task.ContainerID, task.RetryCount, task.UserRetryCount, task.CostUSD, task.ElapsedTimeSec, task.Error,
-		task.ReadyForRetry, task.AgentImage, task.Force, nullableString(task.ParentTaskID),
+		task.ReadyForRetry, task.AgentImage, task.Force, nullableString(task.ParentTaskID), nullableStringValue(task.InlineContentSHA256),
 		timeString(task.CreatedAt), timeString(task.UpdatedAt), nullableTimeString(task.StartedAt), nullableTimeString(task.CompletedAt),
 	)
 	return err
@@ -613,14 +613,15 @@ type sqlScanner interface {
 
 func scanTask(row sqlScanner) (*models.Task, error) {
 	var (
-		t                models.Task
-		allowedToolsJSON string
-		envVarsJSON      string
-		parentTaskID     sql.NullString
-		createdAt        string
-		updatedAt        string
-		startedAt        sql.NullString
-		completedAt      sql.NullString
+		t                   models.Task
+		allowedToolsJSON    string
+		envVarsJSON         string
+		parentTaskID        sql.NullString
+		inlineContentSHA256 sql.NullString
+		createdAt           string
+		updatedAt           string
+		startedAt           sql.NullString
+		completedAt         sql.NullString
 	)
 
 	err := row.Scan(
@@ -631,7 +632,7 @@ func scanTask(row sqlScanner) (*models.Task, error) {
 		&t.PRTitle, &t.PRBody, &t.PRURL, &t.OutputURL,
 		&allowedToolsJSON, &t.ClaudeMD, &envVarsJSON,
 		&t.ContainerID, &t.RetryCount, &t.UserRetryCount, &t.CostUSD, &t.ElapsedTimeSec, &t.Error,
-		&t.ReadyForRetry, &t.AgentImage, &t.Force, &parentTaskID,
+		&t.ReadyForRetry, &t.AgentImage, &t.Force, &parentTaskID, &inlineContentSHA256,
 		&createdAt, &updatedAt, &startedAt, &completedAt,
 	)
 	if err != nil {
@@ -643,6 +644,9 @@ func scanTask(row sqlScanner) (*models.Task, error) {
 	if parentTaskID.Valid {
 		v := parentTaskID.String
 		t.ParentTaskID = &v
+	}
+	if inlineContentSHA256.Valid {
+		t.InlineContentSHA256 = inlineContentSHA256.String
 	}
 
 	if err := unmarshalJSONString(allowedToolsJSON, &t.AllowedTools); err != nil {
@@ -731,6 +735,16 @@ func nullableString(s *string) any {
 		return nil
 	}
 	return *s
+}
+
+// nullableStringValue returns nil for empty strings so that NULL is stored
+// rather than the empty string. Used for nullable TEXT columns whose
+// in-memory representation is a plain string (not *string).
+func nullableStringValue(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }
 
 func parseTime(raw string) (time.Time, error) {

--- a/internal/store/sqlite_test.go
+++ b/internal/store/sqlite_test.go
@@ -1283,3 +1283,45 @@ func TestSQLite_MatchReadings_SimilarityOrdering(t *testing.T) {
 		}
 	}
 }
+
+func TestSQLite_PersistsInlineContentSHA256(t *testing.T) {
+	s := testSQLiteStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	task := &models.Task{
+		ID:                  "bf_INLINE001",
+		Status:              models.TaskStatusPending,
+		TaskMode:            models.TaskModeRead,
+		Harness:             models.HarnessClaudeCode,
+		Prompt:              "markdown://abc123",
+		InlineContentSHA256: "abc123def456",
+		CreatedAt:           now,
+		UpdatedAt:           now,
+	}
+	if err := s.CreateTask(ctx, task); err != nil {
+		t.Fatalf("CreateTask: %v", err)
+	}
+
+	got, err := s.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.InlineContentSHA256 != "abc123def456" {
+		t.Errorf("InlineContentSHA256 = %q, want %q", got.InlineContentSHA256, "abc123def456")
+	}
+}
+
+func TestSQLite_DefaultEmptyInlineContentSHA(t *testing.T) {
+	s := testSQLiteStore(t)
+	ctx := context.Background()
+	task := sqliteTestTask(t, s)
+
+	got, err := s.GetTask(ctx, task.ID)
+	if err != nil {
+		t.Fatalf("GetTask: %v", err)
+	}
+	if got.InlineContentSHA256 != "" {
+		t.Errorf("InlineContentSHA256 = %q, want empty", got.InlineContentSHA256)
+	}
+}

--- a/migrations/004_inline_content.sql
+++ b/migrations/004_inline_content.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE tasks ADD COLUMN inline_content_sha256 TEXT NULL;
+
+-- +goose Down
+
+ALTER TABLE tasks DROP COLUMN inline_content_sha256;

--- a/scripts/ingest-markdown.sh
+++ b/scripts/ingest-markdown.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ingest a local markdown file into the Backlite reading library by POSTing
+# its contents to the existing /api/v1/tasks endpoint with task_mode=read and
+# the file body in the inline_content field. The server persists the body to
+# {DATA_DIR}/ingest/<sha>.md, runs the reader pipeline, and writes a row in
+# the readings table.
+#
+# Usage:
+#   ./scripts/ingest-markdown.sh path/to/note.md
+#
+# Env:
+#   BACKFLOW_URL   Base URL of the Backlite server (default http://localhost:8080)
+
+BACKFLOW_URL="${BACKFLOW_URL:-http://localhost:8080}"
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") <path/to/file.md>
+
+Reads the markdown file at <path>, POSTs it to ${BACKFLOW_URL}/api/v1/tasks
+as a read-mode task with the body in inline_content, and prints the task ID.
+
+The file must exist, be a regular file, be readable, and be non-empty.
+USAGE
+    exit 1
+}
+
+if [ $# -lt 1 ]; then
+    usage
+fi
+
+FILE="$1"
+
+if [ ! -e "$FILE" ]; then
+    echo "Error: file not found: $FILE" >&2
+    exit 1
+fi
+if [ -d "$FILE" ]; then
+    echo "Error: $FILE is a directory; expected a regular file" >&2
+    exit 1
+fi
+if [ ! -f "$FILE" ]; then
+    echo "Error: $FILE is not a regular file" >&2
+    exit 1
+fi
+if [ ! -r "$FILE" ]; then
+    echo "Error: $FILE is not readable" >&2
+    exit 1
+fi
+if [ ! -s "$FILE" ]; then
+    echo "Error: $FILE is empty" >&2
+    exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: jq is required" >&2
+    exit 1
+fi
+
+# Build the JSON body. jq -Rs '.' reads stdin verbatim and produces a JSON
+# string (handles all escaping for us — newlines, quotes, backslashes).
+JSON=$(jq -Rs --arg mode "read" '{
+    task_mode: $mode,
+    inline_content: .
+}' < "$FILE")
+
+RESPONSE=$(curl -s -w "\n%{http_code}" \
+    -X POST "${BACKFLOW_URL}/api/v1/tasks" \
+    -H "Content-Type: application/json" \
+    -d "$JSON")
+
+HTTP_CODE=$(printf '%s\n' "$RESPONSE" | tail -1)
+BODY=$(printf '%s\n' "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" = "201" ]; then
+    TASK_ID=$(printf '%s' "$BODY" | jq -r '.data.id')
+    echo "$TASK_ID"
+else
+    echo "Error (HTTP $HTTP_CODE):" >&2
+    printf '%s\n' "$BODY" | jq . 2>/dev/null || printf '%s\n' "$BODY" >&2
+    exit 1
+fi

--- a/scripts/test-ingest-markdown.sh
+++ b/scripts/test-ingest-markdown.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hermetic smoke test for scripts/ingest-markdown.sh. Spins up a tiny python3
+# HTTP server that records POST bodies into a file and replies 201 with a JSON
+# envelope mimicking the Backlite API. Asserts that the script:
+#   - refuses missing path arg
+#   - refuses a directory
+#   - refuses an empty file
+#   - on a valid file, POSTs JSON whose inline_content equals the file body
+#     and whose task_mode == "read"
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$DIR/ingest-markdown.sh"
+
+if [ ! -x "$SCRIPT" ]; then
+    echo "FAIL: $SCRIPT is missing or not executable" >&2
+    exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "SKIP: python3 not available" >&2
+    exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "SKIP: jq not available" >&2
+    exit 0
+fi
+
+fail() {
+    echo "FAIL: $1" >&2
+    exit 1
+}
+
+cleanup() {
+    if [ -n "${SERVER_PID:-}" ]; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+    fi
+    if [ -n "${TMPROOT:-}" ] && [ -d "$TMPROOT" ]; then
+        rm -rf "$TMPROOT"
+    fi
+}
+trap cleanup EXIT
+
+TMPROOT="$(mktemp -d)"
+CAPTURE_PATH="$TMPROOT/last-post.json"
+SERVER_LOG="$TMPROOT/server.log"
+
+# Pick a free port.
+PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+
+# Start a minimal capture server: writes any POST body to CAPTURE_PATH and
+# replies with 201 and a Backlite-style envelope.
+python3 - "$PORT" "$CAPTURE_PATH" >"$SERVER_LOG" 2>&1 <<'PY' &
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+port = int(sys.argv[1])
+capture_path = sys.argv[2]
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(length)
+        with open(capture_path, "wb") as f:
+            f.write(body)
+        resp = json.dumps({"data": {"id": "bf_TESTSCRIPT", "status": "pending"}}).encode()
+        self.send_response(201)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(resp)))
+        self.end_headers()
+        self.wfile.write(resp)
+
+    def log_message(self, *_):  # silence default logging
+        return
+
+HTTPServer(("127.0.0.1", port), Handler).serve_forever()
+PY
+SERVER_PID=$!
+
+# Wait for the server to come up.
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    if curl -sf -X POST -d '{}' "http://127.0.0.1:$PORT/" -o /dev/null 2>/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+BACKFLOW_URL_TEST="http://127.0.0.1:$PORT"
+
+# 1) missing arg → non-zero
+if BACKFLOW_URL="$BACKFLOW_URL_TEST" bash "$SCRIPT" >/dev/null 2>&1; then
+    fail "expected non-zero exit when no path arg is given"
+fi
+
+# 2) directory arg → non-zero
+DIR_ARG="$TMPROOT/somedir"
+mkdir -p "$DIR_ARG"
+if BACKFLOW_URL="$BACKFLOW_URL_TEST" bash "$SCRIPT" "$DIR_ARG" >/dev/null 2>&1; then
+    fail "expected non-zero exit when path is a directory"
+fi
+
+# 3) empty file → non-zero
+EMPTY_FILE="$TMPROOT/empty.md"
+: > "$EMPTY_FILE"
+if BACKFLOW_URL="$BACKFLOW_URL_TEST" bash "$SCRIPT" "$EMPTY_FILE" >/dev/null 2>&1; then
+    fail "expected non-zero exit when file is empty"
+fi
+
+# 4) valid file → POSTs JSON containing inline_content and task_mode=read
+VALID_FILE="$TMPROOT/note.md"
+cat > "$VALID_FILE" <<'MARKDOWN'
+# Note Title
+
+Some body content.
+MARKDOWN
+
+rm -f "$CAPTURE_PATH"
+
+if ! BACKFLOW_URL="$BACKFLOW_URL_TEST" bash "$SCRIPT" "$VALID_FILE" >/dev/null 2>&1; then
+    fail "expected zero exit on valid file (server log: $(cat "$SERVER_LOG"))"
+fi
+
+if [ ! -f "$CAPTURE_PATH" ]; then
+    fail "server did not capture the POST body"
+fi
+
+if ! jq -e '.task_mode == "read"' "$CAPTURE_PATH" >/dev/null; then
+    fail "POST body missing task_mode=read: $(cat "$CAPTURE_PATH")"
+fi
+
+# inline_content must equal the file body (jq compares strings exactly).
+EXPECTED_BODY="$(cat "$VALID_FILE")"
+ACTUAL_BODY="$(jq -r '.inline_content' "$CAPTURE_PATH")"
+if [ "$EXPECTED_BODY" != "$ACTUAL_BODY" ]; then
+    printf 'inline_content mismatch:\n--- expected ---\n%s\n--- actual ---\n%s\n' "$EXPECTED_BODY" "$ACTUAL_BODY" >&2
+    fail "POST body inline_content does not match input file"
+fi
+
+echo "ok"


### PR DESCRIPTION
## Summary

Closes #77 (slice 1 of PRD #76). Adds an `inline_content` field on `POST /api/v1/tasks` so a read-mode task can be created from a markdown body already on the server's filesystem instead of a URL. The full reader pipeline runs end-to-end unchanged: the orchestrator persists the body under a content-addressed path, bind-mounts it into the reader container, and the in-container fetch step short-circuits to use the file as `extracted.md`.

This is the **tracer-bullet first slice** — markdown-specific dedup and `force=true` overwrite semantics for inline content are deferred to slice 2. The existing prompt-based dispatch dedup still fires once a `markdown://<sha>` row lands in `readings` (because the orchestrator rewrites the task prompt at API time).

## What changed, by layer

- **Schema (`migrations/004_inline_content.sql`)** — new nullable column `tasks.inline_content_sha256 TEXT NULL` (reversible).
- **Deep module (`internal/ingest/`)** — new package with one function: `Write(dataDir, body) → (sha, path, err)`. Atomic `*.tmp` + `os.Rename`, returns `ErrEmptyContent` for nil/empty input.
- **Models (`internal/models/task.go`)** — `Task.InlineContentSHA256` (string) and `CreateTaskRequest.InlineContent` (`*string` so we can distinguish "absent" from "explicitly empty"). `Validate()` rejects an explicit empty string.
- **API task creator (`internal/api/task_creator.go`)** — `NewTask` rejects `inline_content` on non-read tasks. `NewReadTask` rejects `inline_content` paired with a URL-bearing prompt, calls `ingest.Write`, sets `Task.InlineContentSHA256`, and rewrites `Task.Prompt` to `markdown://<sha>`.
- **Store (`internal/store/sqlite.go`)** — `inline_content_sha256` plumbed through `taskColumns`, `INSERT`, and `scanTask`. New helper `nullableStringValue(s string)` for nullable TEXT columns whose in-memory representation is plain `string`.
- **Docker (`internal/orchestrator/docker/docker.go`)** — `buildVolumeFlags(task)` now bind-mounts `<DataDir>/ingest/<sha>.md:/workspace/inline.md:ro` for read tasks with a SHA. `buildEnvFlags` sets `INLINE_CONTENT_PATH=/workspace/inline.md` in the same case. URL-source read tasks and non-read tasks are unaffected.
- **Reader entrypoint (`docker/reader/fetch-and-extract.sh`)** — top-of-script branch on `INLINE_CONTENT_PATH`: copies the file to `extracted.md`, writes a `content.json` sidecar with `content_type=text/markdown`, `content_status=captured`, byte counts, SHA-256, `fetched_at`. Skips `curl` and does **not** write `raw.html`.
- **Operator script (`scripts/ingest-markdown.sh`)** — reads a file from disk, validates non-empty + readable + not-a-directory, JSON-encodes the body with `jq -Rs '.'`, POSTs to `/api/v1/tasks`, prints the task ID.
- **Docs (`api/openapi.yaml`)** — documents `inline_content` on `CreateTaskRequest` and `inline_content_sha256` on `Task`.

## Tests added

Each was written RED → GREEN one cycle at a time (TDD per `CLAUDE.md`):

- `internal/ingest/ingest_test.go` — happy path round-trip, idempotent second call (no tmp debris), empty rejection.
- `internal/models/task_test.go` — `CreateTaskRequest` and `Task` JSON round-trip; `Validate()` rejects explicit empty `inline_content`; allows absent / non-empty.
- `internal/api/task_creator_test.go` — rejects `inline_content` on auto-mode; rejects URL+inline pairing; allows non-URL prompt; persists file + rewrites prompt + emits `task.created`.
- `internal/store/sqlite_test.go` — `inline_content_sha256` round-trip and default-empty round-trip.
- `internal/orchestrator/docker/docker_test.go` — read-mode + SHA produces both the bind-mount and the env var; read-mode without SHA does **not**; non-read tasks are unaffected even if SHA somehow set.
- `docker/reader/test_fetch_and_extract.sh` — extended with an `INLINE_CONTENT_PATH` scenario asserting byte-equal extraction, no `raw.html`, and well-formed sidecar.
- `scripts/test-ingest-markdown.sh` — new hermetic smoke test (python3 capture server) covering missing arg, directory arg, empty file, and a successful POST whose body matches the input file.

## Test plan

- [x] `gofmt -l ./internal/ ./cmd/` — clean
- [x] `make lint` — clean
- [x] `make test` — all packages pass
- [x] `make test-reader-fetch-extract` — `ok` (URL branch and new inline-content branch)
- [x] `bash scripts/test-ingest-markdown.sh` — `ok`
- [x] OpenAPI: `go test ./internal/api/ -run TestOpenAPI` — all pass
- [ ] **Reviewer: end-to-end manual smoke** — build, write a markdown file, run `./scripts/ingest-markdown.sh /tmp/note.md`, verify task progresses pending → running → completed, then `GET /api/v1/readings` returns the row with `url=markdown://<sha>`. Requires a real reader-image build with the updated `fetch-and-extract.sh`.

## What is **not** in this slice

- Markdown-specific `force=true` overwrite semantics for the dispatch-time dedup (slice 2).
- Skill-agent (`docker/skill-agent/skills/read/`) markdown ingestion — still URL-only.
- Web UI, batch ingestion, post-ingest file management, sanitization. (Out of scope per PRD.)