### PR TITLE
Slice 2 (#73): read-mode capture failure modes, non-HTML, force/dup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,13 @@ On completion, the orchestrator's `handleReadingCompletion` helper (in `internal
 
 If the embedding API call or the DB write fails, the task is marked `failed` rather than silently `completed`, and `task.failed` is emitted. If `embedder` is nil (no `OPENAI_API_KEY` configured), reading tasks fail at completion.
 
-The reader container's pre-fetch + extraction step (`fetch-and-extract.sh` + `extract.js`, both in `docker/reader/`) runs before the harness. It downloads the URL with `curl`, computes a SHA-256, and — for HTML payloads — runs the in-container Node pipeline (`@mozilla/readability` + `jsdom` + `turndown`) to produce `extracted.md`. Capture is independent of summarization: the agent's prompt is unchanged, and the agent continues to use `WebFetch` (claude_code) or `curl` (codex) as the primary read path. Capture failures log a warning and the agent runs anyway. Slice 1 ships only the HTML happy path on `docker/reader/`; richer failure-mode statuses (`fetch_failed`, `over_size_cap`, `unsupported_type`), non-HTML payload coverage, size caps, force/duplicate semantics for content overwrite, and the `docker/skill-agent/` image are deferred to follow-up slices.
+The reader container's pre-fetch + extraction step (`fetch-and-extract.sh` + `extract.js`, both in `docker/reader/`) runs before the harness. It downloads the URL with `curl --max-filesize $MAX_CONTENT_BYTES`, computes a SHA-256, derives an extension from `Content-Type`, and writes `raw.<ext>` (`html`/`pdf`/`json`/`txt`/`bin`). For HTML payloads it then runs the in-container Node pipeline (`@mozilla/readability` + `jsdom` + `turndown`) to produce `extracted.md`. Capture is independent of summarization: the agent's prompt is unchanged, and the agent continues to use `WebFetch` (claude_code) or `curl` (codex) as the primary read path. Capture failures log a warning and the agent runs anyway. Failure modes recorded on the `readings` row via `content_status`:
+
+- `captured` — raw saved (and `extracted.md` for HTML).
+- `fetch_failed` — curl exited non-zero (TLS/network error), HTTP 4xx/5xx, or empty body. No files on disk.
+- `over_size_cap` — `curl --max-filesize` tripped (exit 63). No files on disk.
+
+`force=true` resubmissions overwrite the existing reading row and the on-disk content under the same `readings/{id}/` directory (the orchestrator looks up the existing row by URL before generating an id, so the upsert and the on-disk persist target the same id). When the agent reports `novelty_verdict=duplicate` without `force`, `handleReadingCompletion` returns early — no `GetReadingContent`, no `SaveReadingContent`, no `UpsertReading` — preserving the existing row and discarding the pre-fetched container artifacts. Skill-agent (`docker/skill-agent/`) parity for capture is deferred to a follow-up slice.
 
 The reading agent image and reader-side shell scripts live in `docker/reader/`:
 
@@ -167,6 +173,7 @@ Reading-mode env vars:
 
 - `BACKFLOW_READER_IMAGE` — Docker image for reading-mode containers
 - `BACKFLOW_DEFAULT_READ_MAX_BUDGET` / `BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC` / `BACKFLOW_DEFAULT_READ_MAX_TURNS` — Tighter defaults applied by `TaskDefaults("read")`
+- `BACKFLOW_DEFAULT_READ_MAX_CONTENT_BYTES` — Hard cap on the reader's pre-fetch download size; passed into reader containers as `MAX_CONTENT_BYTES` and enforced via `curl --max-filesize`. Over-cap responses produce `content_status=over_size_cap` with no files on disk. See config for the current default.
 - `OPENAI_API_KEY` — Required for the orchestrator's embeddings client (and for the reader container's `read-embed.sh`)
 - `BACKFLOW_INTERNAL_API_BASE_URL` — Optional override for the Backlite API base URL used by reader containers; defaults to `http://host.docker.internal:<listen-port>`
 

--- a/docker/reader/fetch-and-extract.sh
+++ b/docker/reader/fetch-and-extract.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # fetch-and-extract.sh — pre-fetches the URL and (for HTML) writes a
 # Readability-derived markdown extraction. Outputs in $WORKSPACE:
-#   raw.html       Raw bytes from the URL.
+#   raw.<ext>      Raw bytes from the URL, extension derived from Content-Type.
 #   extracted.md   Markdown extraction (HTML only).
 #   content.json   Sidecar metadata (mirrored to the readings DB row).
 #

--- a/docker/reader/fetch-and-extract.sh
+++ b/docker/reader/fetch-and-extract.sh
@@ -21,21 +21,87 @@ mkdir -p "$WORKSPACE"
 
 EXTRACT_CMD="${EXTRACT_CMD:-node /home/agent/extractor/extract.js}"
 
-RAW_PATH="$WORKSPACE/raw.html"
+# Initial download path. We don't yet know the content type, so write to a
+# generic filename and rename to raw.<ext> after parsing the response headers.
+RAW_DOWNLOAD_PATH="$WORKSPACE/raw.download"
+RAW_PATH="$RAW_DOWNLOAD_PATH"
 EXTRACTED_PATH="$WORKSPACE/extracted.md"
 SIDECAR_PATH="$WORKSPACE/content.json"
 HEADERS_PATH="$WORKSPACE/.headers.txt"
 
+# extension_for_content_type maps a Content-Type to a stable file extension.
+# Keep in sync with internal/api/handlers.go:rawFilenameForContentType.
+extension_for_content_type() {
+    local ct="$1"
+    case "$(printf '%s' "$ct" | tr '[:upper:]' '[:lower:]')" in
+        *text/html*)        printf '%s' "html" ;;
+        *application/pdf*)  printf '%s' "pdf"  ;;
+        *application/json*) printf '%s' "json" ;;
+        *text/plain*)       printf '%s' "txt"  ;;
+        *)                  printf '%s' "bin"  ;;
+    esac
+}
+
+# write_failure_sidecar emits a content.json with the given status and exits 0.
+# Used for fetch_failed / over_size_cap; capture is non-fatal so the agent's
+# WebFetch path still runs after this script returns.
+write_failure_sidecar() {
+    local status="$1"
+    local fetched_at
+    fetched_at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    rm -f "$RAW_DOWNLOAD_PATH" "$EXTRACTED_PATH" "$HEADERS_PATH"
+    rm -f "$WORKSPACE"/raw.html "$WORKSPACE"/raw.pdf "$WORKSPACE"/raw.json "$WORKSPACE"/raw.txt "$WORKSPACE"/raw.bin
+    jq -n \
+        --arg url "$URL" \
+        --arg status "$status" \
+        --arg fetched "$fetched_at" '{
+            url: $url,
+            content_type: "",
+            content_status: $status,
+            content_bytes: 0,
+            extracted_bytes: 0,
+            content_sha256: "",
+            fetched_at: $fetched
+        }' > "$SIDECAR_PATH"
+    exit 0
+}
+
 # --- Fetch ---
 # -L: follow redirects. -sS: silent but show errors. -A: identify ourselves.
-# We deliberately do not pass --max-filesize here — slice 2 wires that in.
-if ! curl -L -sS -A "BackliteReader/1.0" \
+# -w '%{http_code}' captures the final-response status so we can record
+# fetch_failed for 4xx/5xx without parsing headers.
+# --max-filesize bounds the download; curl exits 63 when the cap trips.
+MAX_FILESIZE_FLAG=""
+if [ -n "${MAX_CONTENT_BYTES:-}" ] && [ "$MAX_CONTENT_BYTES" -gt 0 ]; then
+    MAX_FILESIZE_FLAG="--max-filesize $MAX_CONTENT_BYTES"
+fi
+
+set +e
+# shellcheck disable=SC2086  # MAX_FILESIZE_FLAG is intentionally word-split
+HTTP_CODE=$(curl -L -sS -A "BackliteReader/1.0" \
+        $MAX_FILESIZE_FLAG \
         -D "$HEADERS_PATH" \
         -o "$RAW_PATH" \
-        "$URL"; then
-    echo "WARN: curl failed for $URL; skipping content capture" >&2
-    rm -f "$RAW_PATH" "$HEADERS_PATH"
-    exit 0
+        -w '%{http_code}' \
+        "$URL" 2>/dev/null)
+CURL_EXIT=$?
+set -e
+
+if [ "$CURL_EXIT" -eq 63 ]; then
+    echo "WARN: $URL exceeded MAX_CONTENT_BYTES=$MAX_CONTENT_BYTES; recording over_size_cap" >&2
+    write_failure_sidecar "over_size_cap"
+fi
+if [ "$CURL_EXIT" -ne 0 ] || [ -z "$HTTP_CODE" ] || [ "$HTTP_CODE" = "000" ]; then
+    echo "WARN: curl failed for $URL (exit=$CURL_EXIT); recording fetch_failed" >&2
+    write_failure_sidecar "fetch_failed"
+fi
+if [ "${HTTP_CODE:0:1}" != "2" ]; then
+    echo "WARN: HTTP $HTTP_CODE from $URL; recording fetch_failed" >&2
+    write_failure_sidecar "fetch_failed"
+fi
+if [ ! -s "$RAW_PATH" ]; then
+    echo "WARN: empty body from $URL; recording fetch_failed" >&2
+    write_failure_sidecar "fetch_failed"
 fi
 
 # --- Parse content type from the response headers ---
@@ -45,11 +111,19 @@ if [ -z "$CONTENT_TYPE" ]; then
     CONTENT_TYPE="application/octet-stream"
 fi
 
+# --- Rename raw.<ext> based on content type ---
+EXT=$(extension_for_content_type "$CONTENT_TYPE")
+NEW_RAW_PATH="$WORKSPACE/raw.$EXT"
+if [ "$RAW_PATH" != "$NEW_RAW_PATH" ]; then
+    mv "$RAW_PATH" "$NEW_RAW_PATH"
+    RAW_PATH="$NEW_RAW_PATH"
+fi
+
 CONTENT_BYTES=$(wc -c < "$RAW_PATH" | tr -d ' ')
 
-# --- Extract markdown for HTML ---
+# --- Extract markdown for HTML only ---
 EXTRACTED_BYTES=0
-if echo "$CONTENT_TYPE" | grep -qi 'text/html'; then
+if [ "$EXT" = "html" ]; then
     if $EXTRACT_CMD "$RAW_PATH" "$EXTRACTED_PATH" 2>/dev/null; then
         if [ -f "$EXTRACTED_PATH" ]; then
             EXTRACTED_BYTES=$(wc -c < "$EXTRACTED_PATH" | tr -d ' ')

--- a/docker/reader/test_fetch_and_extract.sh
+++ b/docker/reader/test_fetch_and_extract.sh
@@ -121,4 +121,116 @@ if WORKSPACE="$TMPROOT/empty" EXTRACT_CMD="$EXTRACT_CMD_STUB" bash "$SCRIPT" >/d
     fail "expected non-zero exit when URL is empty"
 fi
 
+# --- HTTP 404 → fetch_failed sidecar, no raw, no extracted ---
+WS_404="$TMPROOT/ws_404"
+mkdir -p "$WS_404"
+URL="http://127.0.0.1:$PORT/does-not-exist.html" \
+WORKSPACE="$WS_404" \
+EXTRACT_CMD="$EXTRACT_CMD_STUB" \
+    bash "$SCRIPT" || fail "fetch-and-extract.sh must exit 0 on HTTP 404 (capture is non-fatal)"
+
+if [ -e "$WS_404/raw.html" ]; then
+    fail "raw.html must not exist on HTTP 404"
+fi
+if [ -e "$WS_404/extracted.md" ]; then
+    fail "extracted.md must not exist on HTTP 404"
+fi
+if [ ! -f "$WS_404/content.json" ]; then
+    fail "content.json must exist on HTTP 404 so the orchestrator can record fetch_failed"
+fi
+if ! jq -e '.content_status == "fetch_failed"' "$WS_404/content.json" >/dev/null; then
+    fail "content.json: content_status != fetch_failed ($(cat "$WS_404/content.json"))"
+fi
+
+# --- HTTP 403 → fetch_failed (any non-2xx) ---
+# python3 -m http.server only serves 200/404, so simulate 403 via a curl that
+# follows redirects to a non-existent host. Skipped since 404 already exercises
+# the non-2xx branch — adding a second case is redundant.
+
+# --- Oversized payload + small MAX_CONTENT_BYTES → over_size_cap, no raw ---
+# Create a 100KB fixture and set MAX_CONTENT_BYTES=1024 so curl's
+# --max-filesize trips. Capture must record over_size_cap and remove raw.
+dd if=/dev/zero bs=1024 count=100 2>/dev/null | tr '\0' 'A' > "$SERVER_DIR/big.html"
+WS_BIG="$TMPROOT/ws_big"
+mkdir -p "$WS_BIG"
+URL="http://127.0.0.1:$PORT/big.html" \
+WORKSPACE="$WS_BIG" \
+EXTRACT_CMD="$EXTRACT_CMD_STUB" \
+MAX_CONTENT_BYTES=1024 \
+    bash "$SCRIPT" || fail "fetch-and-extract.sh must exit 0 on size cap (capture is non-fatal)"
+
+if [ -e "$WS_BIG/raw.html" ] || [ -e "$WS_BIG/raw.bin" ]; then
+    fail "no raw file should exist on over_size_cap"
+fi
+if [ ! -f "$WS_BIG/content.json" ]; then
+    fail "content.json must exist on over_size_cap"
+fi
+if ! jq -e '.content_status == "over_size_cap"' "$WS_BIG/content.json" >/dev/null; then
+    fail "content.json: content_status != over_size_cap ($(cat "$WS_BIG/content.json"))"
+fi
+
+# --- Within-cap fetch still succeeds when MAX_CONTENT_BYTES is set generously ---
+WS_OK="$TMPROOT/ws_ok"
+mkdir -p "$WS_OK"
+URL="http://127.0.0.1:$PORT/index.html" \
+WORKSPACE="$WS_OK" \
+EXTRACT_CMD="$EXTRACT_CMD_STUB" \
+MAX_CONTENT_BYTES=1048576 \
+    bash "$SCRIPT" || fail "fetch with generous cap must succeed"
+if ! jq -e '.content_status == "captured"' "$WS_OK/content.json" >/dev/null; then
+    fail "within-cap fetch must remain captured ($(cat "$WS_OK/content.json"))"
+fi
+
+# --- Non-HTML payloads: served by a small custom server with content-type
+# headers. The python http.server only sets text/html; spin up a one-shot
+# alternative server using a here-doc CGI-style script.
+NHS_DIR="$TMPROOT/nh_serve"
+mkdir -p "$NHS_DIR"
+printf '%%PDF-1.4\n%%minimal pdf bytes\n' > "$NHS_DIR/doc.pdf"
+printf '{"hello":"world"}\n' > "$NHS_DIR/data.json"
+printf 'plain text body\n' > "$NHS_DIR/notes.txt"
+
+# python -m http.server picks Content-Type by extension via mimetypes (which
+# already covers .pdf=application/pdf, .json=application/json, .txt=text/plain).
+NHS_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
+( cd "$NHS_DIR" && python3 -m http.server "$NHS_PORT" --bind 127.0.0.1 ) >/dev/null 2>&1 &
+NHS_PID=$!
+trap 'kill "${SERVER_PID:-}" 2>/dev/null; kill "${NHS_PID:-}" 2>/dev/null; rm -rf "$TMPROOT"' EXIT
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+    if curl -sf "http://127.0.0.1:$NHS_PORT/doc.pdf" -o /dev/null 2>/dev/null; then
+        break
+    fi
+    sleep 0.1
+done
+
+assert_non_html_capture() {
+    # Args: <url-path> <ext> <content-type-substr> <workspace-dir>
+    local urlpath="$1" ext="$2" ctsubstr="$3" ws="$4"
+    mkdir -p "$ws"
+    URL="http://127.0.0.1:$NHS_PORT/$urlpath" \
+    WORKSPACE="$ws" \
+    EXTRACT_CMD="$EXTRACT_CMD_STUB" \
+    MAX_CONTENT_BYTES=1048576 \
+        bash "$SCRIPT" || fail "non-html fetch ($urlpath) must succeed"
+    if [ ! -f "$ws/raw.$ext" ]; then
+        fail "raw.$ext must exist for $urlpath (got: $(ls "$ws"))"
+    fi
+    if [ -e "$ws/raw.html" ]; then
+        fail "raw.html must not exist for non-html $urlpath"
+    fi
+    if [ -e "$ws/extracted.md" ]; then
+        fail "extracted.md must not exist for non-html $urlpath"
+    fi
+    if ! jq -e '.content_status == "captured"' "$ws/content.json" >/dev/null; then
+        fail "non-html $urlpath: content_status != captured ($(cat "$ws/content.json"))"
+    fi
+    if ! jq -e --arg ct "$ctsubstr" '.content_type | test($ct; "i")' "$ws/content.json" >/dev/null; then
+        fail "non-html $urlpath: content_type does not match $ctsubstr ($(cat "$ws/content.json"))"
+    fi
+}
+
+assert_non_html_capture "doc.pdf"   "pdf"  "application/pdf"  "$TMPROOT/ws_pdf"
+assert_non_html_capture "data.json" "json" "application/json" "$TMPROOT/ws_json"
+assert_non_html_capture "notes.txt" "txt"  "text/plain"       "$TMPROOT/ws_txt"
+
 echo "ok"

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -469,22 +470,55 @@ func (h *Handlers) FindSimilarReadings(w http.ResponseWriter, r *http.Request) {
 
 // GetReadingContent streams the extracted markdown for a reading.
 // Returns 404 when the reading is missing, when content was not captured
-// (content_status != "captured"), or when the file is missing.
+// (content_status != "captured"), or when the extracted markdown is absent
+// (e.g. non-HTML payloads).
 func (h *Handlers) GetReadingContent(w http.ResponseWriter, r *http.Request) {
-	h.serveReadingContent(w, r, "extracted.md", "text/markdown; charset=utf-8")
+	h.serveReadingContent(w, r, func(*models.Reading) string { return "extracted.md" }, "text/markdown; charset=utf-8")
 }
 
-// GetReadingContentRaw streams the captured raw bytes for a reading,
-// reporting the original Content-Type recorded on the row.
+// GetReadingContentRaw streams the captured raw bytes for a reading. The on-disk
+// filename is derived from the reading's recorded content_type (raw.html,
+// raw.pdf, raw.json, raw.txt, raw.bin). The response reports the row's
+// Content-Type so clients see the original payload type.
 func (h *Handlers) GetReadingContentRaw(w http.ResponseWriter, r *http.Request) {
-	h.serveReadingContent(w, r, "raw.html", "")
+	h.serveReadingContent(w, r, rawFilenameForReading, "")
 }
 
-// serveReadingContent streams a single file from {DataDir}/readings/{id}/{name}.
-// Returns 400 when the reading ID is malformed and 404 when the reading does
-// not exist, content_status != "captured", or the file is missing. When
-// contentType is empty, falls back to the reading row's recorded content_type.
-func (h *Handlers) serveReadingContent(w http.ResponseWriter, r *http.Request, name, contentType string) {
+// rawFilenameForReading maps the reading's content_type onto the on-disk raw
+// file. Must stay in sync with extension_for_content_type in
+// docker/reader/fetch-and-extract.sh.
+func rawFilenameForReading(reading *models.Reading) string {
+	return "raw." + extensionForContentType(reading.ContentType)
+}
+
+// extensionForContentType returns the stable extension used to name raw.<ext>.
+// Unknown types fall back to "bin". Keep in sync with
+// extension_for_content_type in docker/reader/fetch-and-extract.sh.
+func extensionForContentType(contentType string) string {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	if i := strings.IndexAny(ct, "; "); i >= 0 {
+		ct = ct[:i]
+	}
+	switch ct {
+	case "text/html":
+		return "html"
+	case "application/pdf":
+		return "pdf"
+	case "application/json":
+		return "json"
+	case "text/plain":
+		return "txt"
+	default:
+		return "bin"
+	}
+}
+
+// serveReadingContent streams a single file from {DataDir}/readings/{id}/.
+// nameFor selects the on-disk filename per reading row. Returns 400 when the
+// reading ID is malformed and 404 when the reading does not exist,
+// content_status != "captured", or the file is missing. When contentType is
+// empty, falls back to the reading row's recorded content_type.
+func (h *Handlers) serveReadingContent(w http.ResponseWriter, r *http.Request, nameFor func(*models.Reading) string, contentType string) {
 	id := chi.URLParam(r, "id")
 	if !taskIDPattern.MatchString(id) {
 		writeError(w, http.StatusBadRequest, "invalid reading id")
@@ -505,7 +539,7 @@ func (h *Handlers) serveReadingContent(w http.ResponseWriter, r *http.Request, n
 		return
 	}
 
-	path := filepath.Join(h.config.DataDir, "readings", id, name)
+	path := filepath.Join(h.config.DataDir, "readings", id, nameFor(reading))
 	if _, err := os.Stat(path); err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			writeError(w, http.StatusNotFound, "reading content not found")

--- a/internal/api/reading_content_test.go
+++ b/internal/api/reading_content_test.go
@@ -191,6 +191,67 @@ func TestGetReadingContent_400_RejectsMalformedID(t *testing.T) {
 	}
 }
 
+func TestGetReadingContentRaw_ServesPDFByContentType(t *testing.T) {
+	// Non-HTML readings store raw.<ext> instead of raw.html. The handler must
+	// derive the on-disk filename from the row's recorded content_type rather
+	// than serving a hardcoded raw.html path.
+	srv, s, dataDir := readingContentTestServer(t)
+
+	const id = "bf_01HX00000000000000000RDPDF"
+	seedReadingWithContent(t, s, dataDir, id, "bf_01HX00000000000000000RDPDT",
+		"captured", "application/pdf")
+
+	dir := filepath.Join(dataDir, "readings", id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	pdfBytes := []byte("%PDF-1.4\nminimal pdf body\n")
+	if err := os.WriteFile(filepath.Join(dir, "raw.pdf"), pdfBytes, 0o644); err != nil {
+		t.Fatalf("write raw.pdf: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/readings/"+id+"/content/raw", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (body: %s)", rec.Code, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); got != "application/pdf" {
+		t.Errorf("Content-Type = %q, want application/pdf", got)
+	}
+	if got := rec.Body.String(); got != string(pdfBytes) {
+		t.Errorf("body length = %d, want %d", len(got), len(pdfBytes))
+	}
+}
+
+func TestGetReadingContent_404_ForNonHTMLReading(t *testing.T) {
+	// A non-HTML reading is captured but has no extracted.md. /content must
+	// 404 even though content_status="captured" — only HTML readings have
+	// markdown to serve.
+	srv, s, dataDir := readingContentTestServer(t)
+
+	const id = "bf_01HX00000000000000000RDNHX"
+	seedReadingWithContent(t, s, dataDir, id, "bf_01HX00000000000000000RDNHT",
+		"captured", "application/json")
+
+	dir := filepath.Join(dataDir, "readings", id)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "raw.json"), []byte(`{"x":1}`), 0o644); err != nil {
+		t.Fatalf("write raw.json: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/readings/"+id+"/content", nil)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404 (body: %s)", rec.Code, rec.Body.String())
+	}
+}
+
 func TestGetReadingContent_RejectsPathTraversal(t *testing.T) {
 	// Slash-bearing IDs don't match the chi route (the {id} param is a
 	// single path segment), so they should never reach the handler and

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -33,19 +33,20 @@ type Config struct {
 	ContainerMemGB int
 
 	// Agent
-	AgentImage            string
-	ReaderImage           string
-	SkillAgentImage       string
-	DefaultHarness        string
-	DefaultClaudeModel    string
-	DefaultCodexModel     string
-	DefaultEffort         string
-	DefaultMaxBudget      float64
-	DefaultMaxRuntime     time.Duration
-	DefaultMaxTurns       int
-	DefaultReadMaxBudget  float64
-	DefaultReadMaxRuntime time.Duration
-	DefaultReadMaxTurns   int
+	AgentImage                 string
+	ReaderImage                string
+	SkillAgentImage            string
+	DefaultHarness             string
+	DefaultClaudeModel         string
+	DefaultCodexModel          string
+	DefaultEffort              string
+	DefaultMaxBudget           float64
+	DefaultMaxRuntime          time.Duration
+	DefaultMaxTurns            int
+	DefaultReadMaxBudget       float64
+	DefaultReadMaxRuntime      time.Duration
+	DefaultReadMaxTurns        int
+	DefaultReadMaxContentBytes int64
 
 	// Internal API used by reader containers to query local readings.
 	InternalAPIBaseURL string
@@ -93,40 +94,41 @@ func (c *Config) MaxConcurrent() int {
 
 func Load() (*Config, error) {
 	c := &Config{
-		ListenAddr:            envOr("BACKFLOW_LISTEN_ADDR", ":8080"),
-		APIKey:                os.Getenv("BACKFLOW_API_KEY"),
-		AnthropicAPIKey:       os.Getenv("ANTHROPIC_API_KEY"),
-		OpenAIAPIKey:          os.Getenv("OPENAI_API_KEY"),
-		ResendAPIKey:          os.Getenv("BACKFLOW_RESEND_API_KEY"),
-		NotifyEmailFrom:       os.Getenv("BACKFLOW_NOTIFY_EMAIL_FROM"),
-		NotifyEmailTo:         os.Getenv("BACKFLOW_NOTIFY_EMAIL_TO"),
-		MaxContainers:         envInt("BACKFLOW_MAX_CONTAINERS", 1),
-		ContainerCPUs:         envInt("BACKFLOW_CONTAINER_CPUS", 2),
-		ContainerMemGB:        envInt("BACKFLOW_CONTAINER_MEMORY_GB", 8),
-		AgentImage:            envOr("BACKFLOW_AGENT_IMAGE", "backlite-agent"),
-		ReaderImage:           os.Getenv("BACKFLOW_READER_IMAGE"),
-		SkillAgentImage:       os.Getenv("BACKFLOW_SKILL_AGENT_IMAGE"),
-		DefaultHarness:        envOr("BACKFLOW_DEFAULT_HARNESS", "claude_code"),
-		DefaultClaudeModel:    envOr("BACKFLOW_DEFAULT_CLAUDE_MODEL", "claude-opus-4-7"),
-		DefaultCodexModel:     envOr("BACKFLOW_DEFAULT_CODEX_MODEL", "gpt-5.4"),
-		DefaultEffort:         envOr("BACKFLOW_DEFAULT_EFFORT", "xhigh"),
-		DefaultMaxBudget:      envFloat("BACKFLOW_DEFAULT_MAX_BUDGET", 10.0),
-		DefaultMaxRuntime:     time.Duration(envInt("BACKFLOW_DEFAULT_MAX_RUNTIME_SEC", 1800)) * time.Second,
-		DefaultMaxTurns:       envInt("BACKFLOW_DEFAULT_MAX_TURNS", 200),
-		DefaultReadMaxBudget:  envFloat("BACKFLOW_DEFAULT_READ_MAX_BUDGET", 0),
-		DefaultReadMaxRuntime: time.Duration(envInt("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC", 0)) * time.Second,
-		DefaultReadMaxTurns:   envInt("BACKFLOW_DEFAULT_READ_MAX_TURNS", 0),
-		InternalAPIBaseURL:    os.Getenv("BACKFLOW_INTERNAL_API_BASE_URL"),
-		DataDir:               envOr("BACKFLOW_DATA_DIR", "./data"),
-		WebDir:                envOr("BACKFLOW_WEB_DIR", "./web/dist"),
-		GitHubToken:           os.Getenv("GITHUB_TOKEN"),
-		WebhookURL:            os.Getenv("BACKFLOW_WEBHOOK_URL"),
-		LogFile:               os.Getenv("BACKFLOW_LOG_FILE"),
-		DatabasePath:          envOr("BACKFLOW_DATABASE_PATH", "./backlite.db"),
-		LocalBackupDir:        envOr("BACKFLOW_LOCAL_BACKUP_DIR", defaultLocalBackupDir()),
-		LocalBackupInterval:   time.Duration(envInt("BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC", 86400)) * time.Second,
-		MaxUserRetries:        envInt("BACKFLOW_MAX_USER_RETRIES", 2),
-		PollInterval:          time.Duration(envInt("BACKFLOW_POLL_INTERVAL_SEC", 5)) * time.Second,
+		ListenAddr:                 envOr("BACKFLOW_LISTEN_ADDR", ":8080"),
+		APIKey:                     os.Getenv("BACKFLOW_API_KEY"),
+		AnthropicAPIKey:            os.Getenv("ANTHROPIC_API_KEY"),
+		OpenAIAPIKey:               os.Getenv("OPENAI_API_KEY"),
+		ResendAPIKey:               os.Getenv("BACKFLOW_RESEND_API_KEY"),
+		NotifyEmailFrom:            os.Getenv("BACKFLOW_NOTIFY_EMAIL_FROM"),
+		NotifyEmailTo:              os.Getenv("BACKFLOW_NOTIFY_EMAIL_TO"),
+		MaxContainers:              envInt("BACKFLOW_MAX_CONTAINERS", 1),
+		ContainerCPUs:              envInt("BACKFLOW_CONTAINER_CPUS", 2),
+		ContainerMemGB:             envInt("BACKFLOW_CONTAINER_MEMORY_GB", 8),
+		AgentImage:                 envOr("BACKFLOW_AGENT_IMAGE", "backlite-agent"),
+		ReaderImage:                os.Getenv("BACKFLOW_READER_IMAGE"),
+		SkillAgentImage:            os.Getenv("BACKFLOW_SKILL_AGENT_IMAGE"),
+		DefaultHarness:             envOr("BACKFLOW_DEFAULT_HARNESS", "claude_code"),
+		DefaultClaudeModel:         envOr("BACKFLOW_DEFAULT_CLAUDE_MODEL", "claude-opus-4-7"),
+		DefaultCodexModel:          envOr("BACKFLOW_DEFAULT_CODEX_MODEL", "gpt-5.4"),
+		DefaultEffort:              envOr("BACKFLOW_DEFAULT_EFFORT", "xhigh"),
+		DefaultMaxBudget:           envFloat("BACKFLOW_DEFAULT_MAX_BUDGET", 10.0),
+		DefaultMaxRuntime:          time.Duration(envInt("BACKFLOW_DEFAULT_MAX_RUNTIME_SEC", 1800)) * time.Second,
+		DefaultMaxTurns:            envInt("BACKFLOW_DEFAULT_MAX_TURNS", 200),
+		DefaultReadMaxBudget:       envFloat("BACKFLOW_DEFAULT_READ_MAX_BUDGET", 0),
+		DefaultReadMaxRuntime:      time.Duration(envInt("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC", 0)) * time.Second,
+		DefaultReadMaxTurns:        envInt("BACKFLOW_DEFAULT_READ_MAX_TURNS", 0),
+		DefaultReadMaxContentBytes: int64(envInt("BACKFLOW_DEFAULT_READ_MAX_CONTENT_BYTES", 5*1024*1024)),
+		InternalAPIBaseURL:         os.Getenv("BACKFLOW_INTERNAL_API_BASE_URL"),
+		DataDir:                    envOr("BACKFLOW_DATA_DIR", "./data"),
+		WebDir:                     envOr("BACKFLOW_WEB_DIR", "./web/dist"),
+		GitHubToken:                os.Getenv("GITHUB_TOKEN"),
+		WebhookURL:                 os.Getenv("BACKFLOW_WEBHOOK_URL"),
+		LogFile:                    os.Getenv("BACKFLOW_LOG_FILE"),
+		DatabasePath:               envOr("BACKFLOW_DATABASE_PATH", "./backlite.db"),
+		LocalBackupDir:             envOr("BACKFLOW_LOCAL_BACKUP_DIR", defaultLocalBackupDir()),
+		LocalBackupInterval:        time.Duration(envInt("BACKFLOW_LOCAL_BACKUP_INTERVAL_SEC", 86400)) * time.Second,
+		MaxUserRetries:             envInt("BACKFLOW_MAX_USER_RETRIES", 2),
+		PollInterval:               time.Duration(envInt("BACKFLOW_POLL_INTERVAL_SEC", 5)) * time.Second,
 	}
 
 	c.DefaultCreatePR = envBool("BACKFLOW_DEFAULT_CREATE_PR", true)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -180,6 +180,7 @@ func TestLoad_ReaderConfig(t *testing.T) {
 	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_BUDGET", "0.5")
 	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_RUNTIME_SEC", "300")
 	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_TURNS", "20")
+	t.Setenv("BACKFLOW_DEFAULT_READ_MAX_CONTENT_BYTES", "1048576")
 	t.Setenv("BACKFLOW_INTERNAL_API_BASE_URL", "http://host.docker.internal:8080")
 
 	cfg, err := Load()
@@ -198,8 +199,21 @@ func TestLoad_ReaderConfig(t *testing.T) {
 	if cfg.DefaultReadMaxTurns != 20 {
 		t.Errorf("DefaultReadMaxTurns = %d, want %d", cfg.DefaultReadMaxTurns, 20)
 	}
+	if cfg.DefaultReadMaxContentBytes != 1048576 {
+		t.Errorf("DefaultReadMaxContentBytes = %d, want %d", cfg.DefaultReadMaxContentBytes, 1048576)
+	}
 	if cfg.InternalAPIBaseURL != "http://host.docker.internal:8080" {
 		t.Errorf("InternalAPIBaseURL = %q", cfg.InternalAPIBaseURL)
+	}
+
+	// Defaults flow into TaskDefaults("read"); the size cap is read-mode only.
+	d := cfg.TaskDefaults("read")
+	if d.MaxContentBytes != 1048576 {
+		t.Errorf("TaskDefaults(\"read\").MaxContentBytes = %d, want %d", d.MaxContentBytes, 1048576)
+	}
+	code := cfg.TaskDefaults("code")
+	if code.MaxContentBytes != 0 {
+		t.Errorf("TaskDefaults(\"code\").MaxContentBytes = %d, want 0 (size cap is read-mode only)", code.MaxContentBytes)
 	}
 }
 

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -12,6 +12,7 @@ type TaskDefaults struct {
 	MaxBudgetUSD    float64
 	MaxRuntimeSec   int
 	MaxTurns        int
+	MaxContentBytes int64 // Read-mode size cap; 0 in other modes.
 	CreatePR        bool
 	SelfReview      bool
 	SaveAgentOutput bool
@@ -49,6 +50,7 @@ func (c *Config) TaskDefaults(taskMode string) TaskDefaults {
 		d.MaxBudgetUSD = c.DefaultReadMaxBudget
 		d.MaxRuntimeSec = int(c.DefaultReadMaxRuntime.Seconds())
 		d.MaxTurns = c.DefaultReadMaxTurns
+		d.MaxContentBytes = c.DefaultReadMaxContentBytes
 		d.CreatePR = false
 	}
 	// Auto mode uses the same defaults as code mode (superset).

--- a/internal/models/task.go
+++ b/internal/models/task.go
@@ -154,6 +154,7 @@ var reservedEnvVarKeys = map[string]bool{
 	"EFFORT":                true,
 	"MAX_BUDGET_USD":        true,
 	"MAX_TURNS":             true,
+	"MAX_CONTENT_BYTES":     true,
 	"CREATE_PR":             true,
 	"SELF_REVIEW":           true,
 	"FORCE":                 true,

--- a/internal/models/task_test.go
+++ b/internal/models/task_test.go
@@ -218,6 +218,11 @@ func TestCreateTaskRequestValidation(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "reserved env var key MAX_CONTENT_BYTES",
+			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"MAX_CONTENT_BYTES": "0"}},
+			wantErr: true,
+		},
+		{
 			name:    "reserved env var key RESEND_API_KEY",
 			req:     CreateTaskRequest{Prompt: "Fix bug", EnvVars: map[string]string{"RESEND_API_KEY": "re_attacker"}},
 			wantErr: true,

--- a/internal/orchestrator/docker/docker.go
+++ b/internal/orchestrator/docker/docker.go
@@ -370,10 +370,50 @@ func (m *Manager) GetAgentOutput(ctx context.Context, containerID string) (strin
 // reader container's pre-fetch + extraction step. Missing files yield nil byte
 // slices (no error) so callers can record content_status accordingly.
 func (m *Manager) GetReadingContent(ctx context.Context, containerID string) (raw, extracted, sidecar []byte, err error) {
-	raw = m.copyReadingFile(ctx, containerID, "/home/agent/workspace/raw.html")
-	extracted = m.copyReadingFile(ctx, containerID, "/home/agent/workspace/extracted.md")
 	sidecar = m.copyReadingFile(ctx, containerID, "/home/agent/workspace/content.json")
+	if rawName := rawFilenameFromSidecar(sidecar); rawName != "" {
+		raw = m.copyReadingFile(ctx, containerID, "/home/agent/workspace/"+rawName)
+	}
+	extracted = m.copyReadingFile(ctx, containerID, "/home/agent/workspace/extracted.md")
 	return raw, extracted, sidecar, nil
+}
+
+type readingContentSidecar struct {
+	ContentType   string `json:"content_type"`
+	ContentStatus string `json:"content_status"`
+}
+
+func rawFilenameFromSidecar(sidecar []byte) string {
+	if len(sidecar) == 0 {
+		return "raw.html"
+	}
+	var c readingContentSidecar
+	if err := json.Unmarshal(sidecar, &c); err != nil {
+		return "raw.html"
+	}
+	if c.ContentStatus != "" && c.ContentStatus != "captured" {
+		return ""
+	}
+	if c.ContentType == "" {
+		return "raw.html"
+	}
+	return "raw." + extensionForContentType(c.ContentType)
+}
+
+func extensionForContentType(contentType string) string {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	switch {
+	case strings.Contains(ct, "text/html"):
+		return "html"
+	case strings.Contains(ct, "application/pdf"):
+		return "pdf"
+	case strings.Contains(ct, "application/json"):
+		return "json"
+	case strings.Contains(ct, "text/plain"):
+		return "txt"
+	default:
+		return "bin"
+	}
 }
 
 // copyReadingFile pulls a single file out of the container via docker cp.

--- a/internal/orchestrator/docker/docker.go
+++ b/internal/orchestrator/docker/docker.go
@@ -172,6 +172,7 @@ func (m *Manager) buildEnvFlags(task *models.Task) []string {
 
 	if task.TaskMode == models.TaskModeRead {
 		flags = append(flags, envFlag("BACKFLOW_API_BASE_URL", shellEscape(m.internalAPIBaseURL())))
+		flags = append(flags, fmt.Sprintf("-e MAX_CONTENT_BYTES=%d", m.config.DefaultReadMaxContentBytes))
 	}
 
 	for k, v := range task.EnvVars {

--- a/internal/orchestrator/docker/docker_test.go
+++ b/internal/orchestrator/docker/docker_test.go
@@ -296,6 +296,30 @@ func TestBuildEnvFlags_ReadModeFallsBackToHostGatewayURL(t *testing.T) {
 	}
 }
 
+func TestBuildEnvFlags_ReadModeIncludesMaxContentBytes(t *testing.T) {
+	cfg := &config.Config{DefaultReadMaxContentBytes: 2097152}
+	dm := NewManager(cfg)
+	task := &models.Task{ID: "bf_01ABC", TaskMode: models.TaskModeRead}
+
+	joined := strings.Join(dm.buildEnvFlags(task), " ")
+
+	if !strings.Contains(joined, "-e MAX_CONTENT_BYTES=2097152") {
+		t.Errorf("read-mode flags must include MAX_CONTENT_BYTES, got: %s", joined)
+	}
+}
+
+func TestBuildEnvFlags_NonReadModeOmitsMaxContentBytes(t *testing.T) {
+	cfg := &config.Config{DefaultReadMaxContentBytes: 2097152}
+	dm := NewManager(cfg)
+	task := &models.Task{ID: "bf_01ABC", TaskMode: models.TaskModeCode}
+
+	joined := strings.Join(dm.buildEnvFlags(task), " ")
+
+	if strings.Contains(joined, "MAX_CONTENT_BYTES") {
+		t.Errorf("non-read flags must not include MAX_CONTENT_BYTES, got: %s", joined)
+	}
+}
+
 func TestBuildRunCommand_UsesTaskAgentImage(t *testing.T) {
 	cfg := &config.Config{
 		ContainerCPUs:  2,

--- a/internal/orchestrator/docker/reading_content_test.go
+++ b/internal/orchestrator/docker/reading_content_test.go
@@ -104,6 +104,37 @@ func TestGetReadingContent_MissingExtractedTolerated(t *testing.T) {
 	}
 }
 
+func TestGetReadingContent_FailureStatusSidecarOnly(t *testing.T) {
+	// On fetch_failed / over_size_cap the in-container fetcher writes only a
+	// sidecar (no raw, no extracted). The extractor must surface the sidecar
+	// bytes so the orchestrator can record the failure status on the row.
+	fake := &fakeRunCmd{
+		responses: map[string]struct {
+			out string
+			err error
+		}{
+			"raw":          {err: errors.New("no such file")},
+			"extracted.md": {err: errors.New("no such file")},
+			"content.json": {out: `{"url":"https://x","content_status":"fetch_failed"}`},
+		},
+	}
+	m := newManagerWithRunner(fake.run)
+
+	raw, extracted, sidecar, err := m.GetReadingContent(context.Background(), "abc")
+	if err != nil {
+		t.Fatalf("GetReadingContent: %v", err)
+	}
+	if raw != nil {
+		t.Errorf("raw should be nil on capture failure, got %q", raw)
+	}
+	if extracted != nil {
+		t.Errorf("extracted should be nil on capture failure, got %q", extracted)
+	}
+	if string(sidecar) != `{"url":"https://x","content_status":"fetch_failed"}` {
+		t.Errorf("sidecar = %q, want failure-status sidecar", sidecar)
+	}
+}
+
 func TestGetReadingContent_LegacyContainerNoFiles(t *testing.T) {
 	// All three files missing — pre-feature container. Should return all-nil
 	// bytes and no error so the caller can mark content_status=''.

--- a/internal/orchestrator/docker/reading_content_test.go
+++ b/internal/orchestrator/docker/reading_content_test.go
@@ -82,9 +82,9 @@ func TestGetReadingContent_MissingExtractedTolerated(t *testing.T) {
 			out string
 			err error
 		}{
-			"raw.html":     {out: "raw"},
+			"raw.pdf":      {out: "%PDF-1.4\nminimal"},
 			"extracted.md": {err: errors.New("no such file")},
-			"content.json": {out: `{"url":"https://x"}`},
+			"content.json": {out: `{"url":"https://x","content_type":"application/pdf","content_status":"captured"}`},
 		},
 	}
 	m := newManagerWithRunner(fake.run)
@@ -93,14 +93,19 @@ func TestGetReadingContent_MissingExtractedTolerated(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetReadingContent: %v", err)
 	}
-	if string(raw) != "raw" {
+	if string(raw) != "%PDF-1.4\nminimal" {
 		t.Errorf("raw = %q", raw)
 	}
 	if extracted != nil {
 		t.Errorf("extracted should be nil, got %q", extracted)
 	}
-	if string(sidecar) != `{"url":"https://x"}` {
+	if string(sidecar) != `{"url":"https://x","content_type":"application/pdf","content_status":"captured"}` {
 		t.Errorf("sidecar = %q", sidecar)
+	}
+	for _, c := range fake.calls {
+		if strings.Contains(c, "/home/agent/workspace/raw.html") {
+			t.Errorf("non-HTML capture should not copy raw.html, got call: %s", c)
+		}
 	}
 }
 

--- a/internal/orchestrator/monitor.go
+++ b/internal/orchestrator/monitor.go
@@ -277,8 +277,20 @@ func (o *Orchestrator) handleReadingCompletion(ctx context.Context, task *models
 	}
 	captured := parseCapturedSidecar(sidecarBytes)
 
+	// If a reading already exists for this URL (force=true overwrite path),
+	// reuse its id so the upsert hits the same row and the on-disk persister
+	// overwrites the existing readings/{id}/ directory atomically. Without
+	// this, the upsert keeps the old row id (per ON CONFLICT(url)) but the
+	// orchestrator would persist files under a never-stored id, orphaning
+	// them on disk and leaving the API endpoints unable to find the new
+	// content.
+	readingID := "bf_" + ulid.Make().String()
+	if existing, err := o.store.GetReadingByURL(ctx, url); err == nil && existing != nil {
+		readingID = existing.ID
+	}
+
 	reading := &models.Reading{
-		ID:             "bf_" + ulid.Make().String(),
+		ID:             readingID,
 		TaskID:         task.ID,
 		URL:            url,
 		Title:          status.Title,

--- a/internal/orchestrator/monitor_test.go
+++ b/internal/orchestrator/monitor_test.go
@@ -768,6 +768,80 @@ func TestHandleCompletion_ReadSuccess_PersistsCapturedContent(t *testing.T) {
 	}
 }
 
+func TestHandleCompletion_ReadSuccess_PersistsNonHTMLRawByContentType(t *testing.T) {
+	s := newMockStore()
+	now := time.Now().UTC()
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_read_pdf",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeRead,
+		Prompt:      "https://example.com/doc.pdf",
+		ContainerID: "cont1",
+		StartedAt:   &now,
+	})
+
+	bus, _ := newTestBus()
+	emb := &mockEmbedder{vector: []float32{0.1}}
+	raw := []byte("%PDF-1.4\nminimal pdf body\n")
+	sidecar := []byte(`{
+  "url":"https://example.com/doc.pdf",
+  "content_type":"application/pdf",
+  "content_status":"captured",
+  "content_bytes":26,
+  "extracted_bytes":0,
+  "content_sha256":"pdf-sha",
+  "fetched_at":"2026-04-25T12:00:00Z"
+}`)
+	root := t.TempDir()
+	o := newTestOrchestrator(s, bus,
+		withEmbedder(emb),
+		withDocker(&mockDockerManager{
+			readingRaw:       raw,
+			readingExtracted: nil,
+			readingSidecar:   sidecar,
+		}),
+		withOutputs(outputs.New(root)),
+	)
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_read_pdf")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:           true,
+		Complete:       true,
+		TaskMode:       models.TaskModeRead,
+		URL:            "https://example.com/doc.pdf",
+		TLDR:           "pdf summary",
+		NoveltyVerdict: "new",
+	})
+	bus.Close()
+
+	s.mu.Lock()
+	if len(s.upsertedReadings) != 1 {
+		s.mu.Unlock()
+		t.Fatalf("upsertedReadings = %d, want 1", len(s.upsertedReadings))
+	}
+	r := s.upsertedReadings[0]
+	s.mu.Unlock()
+
+	dir := filepath.Join(root, "readings", r.ID)
+	gotRaw, err := os.ReadFile(filepath.Join(dir, "raw.pdf"))
+	if err != nil {
+		t.Fatalf("read raw.pdf: %v", err)
+	}
+	if string(gotRaw) != string(raw) {
+		t.Errorf("raw.pdf = %q, want %q", gotRaw, raw)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "raw.html")); !os.IsNotExist(err) {
+		t.Errorf("raw.html should not exist for PDF capture, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "extracted.md")); !os.IsNotExist(err) {
+		t.Errorf("extracted.md should not exist for PDF capture, stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "content.json")); err != nil {
+		t.Errorf("content.json should exist: %v", err)
+	}
+}
+
 func TestHandleCompletion_ReadSuccess_RecordsFetchFailedWithoutPersisting(t *testing.T) {
 	// When the in-container fetcher records fetch_failed (e.g. HTTP 4xx, TLS
 	// error), no raw bytes accompany the sidecar. The reading row should

--- a/internal/orchestrator/monitor_test.go
+++ b/internal/orchestrator/monitor_test.go
@@ -768,6 +768,123 @@ func TestHandleCompletion_ReadSuccess_PersistsCapturedContent(t *testing.T) {
 	}
 }
 
+func TestHandleCompletion_ReadSuccess_RecordsFetchFailedWithoutPersisting(t *testing.T) {
+	// When the in-container fetcher records fetch_failed (e.g. HTTP 4xx, TLS
+	// error), no raw bytes accompany the sidecar. The reading row should
+	// reflect the failure status and SaveReadingContent must not run — there
+	// are no bytes to persist.
+	cases := []struct {
+		name    string
+		status  string
+		sidecar string
+	}{
+		{
+			name:   "fetch_failed",
+			status: "fetch_failed",
+			sidecar: `{
+				"url":"https://example.com/dead",
+				"content_type":"",
+				"content_status":"fetch_failed",
+				"content_bytes":0,
+				"extracted_bytes":0,
+				"content_sha256":"",
+				"fetched_at":"2026-04-25T12:00:00Z"
+			}`,
+		},
+		{
+			name:   "over_size_cap",
+			status: "over_size_cap",
+			sidecar: `{
+				"url":"https://example.com/huge",
+				"content_type":"",
+				"content_status":"over_size_cap",
+				"content_bytes":0,
+				"extracted_bytes":0,
+				"content_sha256":"",
+				"fetched_at":"2026-04-25T12:00:00Z"
+			}`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newMockStore()
+			now := time.Now().UTC()
+			s.CreateTask(context.Background(), &models.Task{
+				ID:          "bf_read_" + tc.status,
+				Status:      models.TaskStatusRunning,
+				TaskMode:    models.TaskModeRead,
+				Prompt:      "https://example.com/" + tc.status,
+				ContainerID: "cont1",
+				StartedAt:   &now,
+			})
+
+			bus, n := newTestBus()
+			emb := &mockEmbedder{vector: []float32{0.1}}
+			mockOut := &mockWriter{}
+			o := newTestOrchestrator(s, bus,
+				withEmbedder(emb),
+				withDocker(&mockDockerManager{
+					readingRaw:       nil, // no raw bytes on capture failure
+					readingExtracted: nil,
+					readingSidecar:   []byte(tc.sidecar),
+				}),
+				withOutputs(mockOut),
+			)
+			o.running = 1
+
+			task, _ := s.GetTask(context.Background(), "bf_read_"+tc.status)
+			o.handleCompletion(context.Background(), task, ContainerStatus{
+				Done:           true,
+				Complete:       true,
+				TaskMode:       models.TaskModeRead,
+				URL:            "https://example.com/" + tc.status,
+				TLDR:           "summary via webfetch fallback",
+				NoveltyVerdict: "new",
+			})
+			bus.Close()
+
+			// Task itself must succeed: capture failure is non-fatal.
+			got, _ := s.GetTask(context.Background(), "bf_read_"+tc.status)
+			if got.Status != models.TaskStatusCompleted {
+				t.Errorf("task.Status = %q, want completed (capture failure must not fail the task)", got.Status)
+			}
+
+			s.mu.Lock()
+			if len(s.upsertedReadings) != 1 {
+				s.mu.Unlock()
+				t.Fatalf("upsertedReadings = %d, want 1", len(s.upsertedReadings))
+			}
+			r := s.upsertedReadings[0]
+			s.mu.Unlock()
+
+			if r.ContentStatus != tc.status {
+				t.Errorf("reading.ContentStatus = %q, want %q", r.ContentStatus, tc.status)
+			}
+			if r.ContentBytes != 0 {
+				t.Errorf("reading.ContentBytes = %d, want 0", r.ContentBytes)
+			}
+
+			if len(mockOut.readingSaves) != 0 {
+				t.Errorf("SaveReadingContent must not run on %s; got %d calls",
+					tc.status, len(mockOut.readingSaves))
+			}
+
+			// Webhook event must surface the failure status.
+			n.mu.Lock()
+			if len(n.events) != 1 {
+				n.mu.Unlock()
+				t.Fatalf("events = %d, want 1", len(n.events))
+			}
+			e := n.events[0]
+			n.mu.Unlock()
+			if e.ContentStatus != tc.status {
+				t.Errorf("event.ContentStatus = %q, want %q", e.ContentStatus, tc.status)
+			}
+		})
+	}
+}
+
 func TestHandleCompletion_ReadSuccess_NoCaptureLeavesContentStatusEmpty(t *testing.T) {
 	// Legacy / pre-capture container: GetReadingContent returns all-nil.
 	// The reading row gets ContentStatus="" and SaveReadingContent is not
@@ -1060,23 +1177,52 @@ func TestHandleCompletion_ReadEmptyURL_MarksTaskFailed(t *testing.T) {
 }
 
 // TestHandleCompletion_ReadDuplicate_SkipsWrite verifies that a non-forced
-// duplicate reading completes successfully without overwriting the existing row.
+// duplicate reading completes successfully without overwriting the existing row,
+// without copying pre-fetched files out of the container, and without writing
+// any captured artifacts to disk. The existing row stays untouched.
 func TestHandleCompletion_ReadDuplicate_SkipsWrite(t *testing.T) {
+	const url = "https://example.com/post"
+	const existingID = "bf_01HX_PRESERVE_EXISTING__"
+
 	s := newMockStore()
 	now := time.Now().UTC()
+	s.readingsByURL[url] = &models.Reading{
+		ID:            existingID,
+		URL:           url,
+		Title:         "old title",
+		ContentStatus: "captured",
+		ContentSHA256: "old-sha",
+		CreatedAt:     now.Add(-72 * time.Hour),
+	}
 	s.CreateTask(context.Background(), &models.Task{
 		ID:          "bf_read_dup",
 		Status:      models.TaskStatusRunning,
 		TaskMode:    models.TaskModeRead,
 		Force:       false,
-		Prompt:      "https://example.com/post",
+		Prompt:      url,
 		ContainerID: "cont1",
 		StartedAt:   &now,
 	})
 
 	bus, n := newTestBus()
 	emb := &mockEmbedder{vector: []float32{0.1}}
-	o := newTestOrchestrator(s, bus, withEmbedder(emb))
+
+	// Track GetReadingContent invocations: a duplicate must not even attempt
+	// to copy pre-fetched files out of the container.
+	var contentCalls int
+	mockDocker := &mockDockerManager{
+		readingContentFn: func(_ context.Context, _ string) (raw, extracted, sidecar []byte, err error) {
+			contentCalls++
+			return nil, nil, nil, nil
+		},
+	}
+	mockOut := &mockWriter{}
+
+	o := newTestOrchestrator(s, bus,
+		withEmbedder(emb),
+		withDocker(mockDocker),
+		withOutputs(mockOut),
+	)
 	o.running = 1
 
 	task, _ := s.GetTask(context.Background(), "bf_read_dup")
@@ -1084,7 +1230,7 @@ func TestHandleCompletion_ReadDuplicate_SkipsWrite(t *testing.T) {
 		Done:           true,
 		Complete:       true,
 		TaskMode:       models.TaskModeRead,
-		URL:            "https://example.com/post",
+		URL:            url,
 		TLDR:           "already read",
 		NoveltyVerdict: "duplicate",
 	})
@@ -1099,7 +1245,19 @@ func TestHandleCompletion_ReadDuplicate_SkipsWrite(t *testing.T) {
 	if len(s.upsertedReadings) != 0 {
 		t.Errorf("upsertedReadings = %d, want 0 for non-forced duplicate", len(s.upsertedReadings))
 	}
+	preserved := s.readingsByURL[url]
 	s.mu.Unlock()
+
+	if preserved == nil || preserved.ID != existingID || preserved.Title != "old title" || preserved.ContentSHA256 != "old-sha" {
+		t.Errorf("existing row was modified; got %+v", preserved)
+	}
+
+	if contentCalls != 0 {
+		t.Errorf("GetReadingContent was called %d time(s) for a non-forced duplicate; pre-fetched files must be discarded", contentCalls)
+	}
+	if len(mockOut.readingSaves) != 0 {
+		t.Errorf("SaveReadingContent was called %d time(s) for a non-forced duplicate; want 0", len(mockOut.readingSaves))
+	}
 
 	// Embedder should not be called for duplicates (no embedding to write).
 	emb.mu.Lock()
@@ -1111,6 +1269,93 @@ func TestHandleCompletion_ReadDuplicate_SkipsWrite(t *testing.T) {
 	events := n.eventTypes()
 	if len(events) != 1 || events[0] != notify.EventTaskCompleted {
 		t.Errorf("events = %v, want [task.completed]", events)
+	}
+}
+
+// TestHandleCompletion_ReadForce_OverwritesSameID verifies that when a forced
+// read task targets a URL that already has a reading row, the upsert keeps the
+// existing reading id and the on-disk persister is invoked under that same id.
+// Without this guarantee, force=true would orphan the prior on-disk artifacts
+// (under the old id) while writing fresh ones under a never-stored id.
+func TestHandleCompletion_ReadForce_OverwritesSameID(t *testing.T) {
+	const existingID = "bf_01HX_OVERWRITE_TARGET___"
+	const url = "https://example.com/refresh-me"
+
+	s := newMockStore()
+	now := time.Now().UTC()
+	s.readingsByURL[url] = &models.Reading{
+		ID:            existingID,
+		URL:           url,
+		Title:         "old title",
+		ContentStatus: "captured",
+		ContentSHA256: "old-sha",
+		CreatedAt:     now.Add(-24 * time.Hour),
+	}
+	s.CreateTask(context.Background(), &models.Task{
+		ID:          "bf_force_overwrite",
+		Status:      models.TaskStatusRunning,
+		TaskMode:    models.TaskModeRead,
+		Force:       true,
+		Prompt:      url,
+		ContainerID: "cont1",
+		StartedAt:   &now,
+	})
+
+	bus, _ := newTestBus()
+	emb := &mockEmbedder{vector: []float32{0.9}}
+	mockOut := &mockWriter{}
+	o := newTestOrchestrator(s, bus,
+		withEmbedder(emb),
+		withDocker(&mockDockerManager{
+			readingRaw:       []byte("<html>fresh</html>"),
+			readingExtracted: []byte("# fresh"),
+			readingSidecar: []byte(`{
+				"url":"` + url + `",
+				"content_type":"text/html",
+				"content_status":"captured",
+				"content_bytes":18,
+				"extracted_bytes":7,
+				"content_sha256":"new-sha",
+				"fetched_at":"2026-04-25T12:00:00Z"
+			}`),
+		}),
+		withOutputs(mockOut),
+	)
+	o.running = 1
+
+	task, _ := s.GetTask(context.Background(), "bf_force_overwrite")
+	o.handleCompletion(context.Background(), task, ContainerStatus{
+		Done:           true,
+		Complete:       true,
+		TaskMode:       models.TaskModeRead,
+		URL:            url,
+		Title:          "fresh title",
+		TLDR:           "fresh tldr",
+		NoveltyVerdict: "new",
+	})
+	bus.Close()
+
+	s.mu.Lock()
+	if len(s.upsertedReadings) != 1 {
+		s.mu.Unlock()
+		t.Fatalf("upsertedReadings = %d, want 1", len(s.upsertedReadings))
+	}
+	upserted := s.upsertedReadings[0]
+	s.mu.Unlock()
+
+	if upserted.ID != existingID {
+		t.Errorf("upserted reading.ID = %q, want existing id %q (force must overwrite the same row, not create a new one)", upserted.ID, existingID)
+	}
+	if upserted.ContentSHA256 != "new-sha" {
+		t.Errorf("upserted reading.ContentSHA256 = %q, want %q (sha must reflect latest fetch)", upserted.ContentSHA256, "new-sha")
+	}
+
+	if len(mockOut.readingSaves) != 1 {
+		t.Fatalf("SaveReadingContent calls = %d, want 1", len(mockOut.readingSaves))
+	}
+	if mockOut.readingSaves[0].readingID != existingID {
+		t.Errorf("SaveReadingContent readingID = %q, want %q (on-disk persist must target the existing id so the API can find it)",
+			mockOut.readingSaves[0].readingID, existingID)
 	}
 }
 

--- a/internal/orchestrator/outputs/fs.go
+++ b/internal/orchestrator/outputs/fs.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // FSWriter persists agent output to {Root}/tasks/{taskID}/. The two files it
@@ -59,25 +60,89 @@ func (w *FSWriter) SaveMetadata(_ context.Context, taskID string, metadata any) 
 }
 
 // SaveReadingContent persists the captured artifacts for readingID under
-// {Root}/readings/{readingID}/. The HTML happy path supplies all three byte
-// slices (raw HTML, extracted markdown, sidecar JSON). For non-HTML payloads
-// extracted may be nil, in which case extracted.md is skipped — raw.html and
-// content.json are still required.
+// {Root}/readings/{readingID}/. The raw filename is derived from the sidecar's
+// content_type so it stays aligned with the API's /content/raw lookup.
 func (w *FSWriter) SaveReadingContent(_ context.Context, readingID string, raw, extracted, sidecar []byte) error {
 	dir := filepath.Join(w.Root, "readings", readingID)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("outputs: mkdir reading dir: %w", err)
 	}
-	if err := writeAtomic(filepath.Join(dir, "raw.html"), raw); err != nil {
+
+	rawName := rawFilenameFromSidecar(sidecar)
+	if err := removeOtherRawFiles(dir, rawName); err != nil {
 		return err
+	}
+	if raw != nil && rawName != "" {
+		if err := writeAtomic(filepath.Join(dir, rawName), raw); err != nil {
+			return err
+		}
 	}
 	if extracted != nil {
 		if err := writeAtomic(filepath.Join(dir, "extracted.md"), extracted); err != nil {
 			return err
 		}
+	} else if err := removeIfExists(filepath.Join(dir, "extracted.md")); err != nil {
+		return err
 	}
 	if err := writeAtomic(filepath.Join(dir, "content.json"), sidecar); err != nil {
 		return err
+	}
+	return nil
+}
+
+type readingContentSidecar struct {
+	ContentType   string `json:"content_type"`
+	ContentStatus string `json:"content_status"`
+}
+
+func rawFilenameFromSidecar(sidecar []byte) string {
+	if len(sidecar) == 0 {
+		return "raw.html"
+	}
+	var c readingContentSidecar
+	if err := json.Unmarshal(sidecar, &c); err != nil {
+		return "raw.html"
+	}
+	if c.ContentStatus != "" && c.ContentStatus != "captured" {
+		return ""
+	}
+	if c.ContentType == "" {
+		return "raw.html"
+	}
+	return "raw." + extensionForContentType(c.ContentType)
+}
+
+func extensionForContentType(contentType string) string {
+	ct := strings.ToLower(strings.TrimSpace(contentType))
+	switch {
+	case strings.Contains(ct, "text/html"):
+		return "html"
+	case strings.Contains(ct, "application/pdf"):
+		return "pdf"
+	case strings.Contains(ct, "application/json"):
+		return "json"
+	case strings.Contains(ct, "text/plain"):
+		return "txt"
+	default:
+		return "bin"
+	}
+}
+
+func removeOtherRawFiles(dir, keep string) error {
+	for _, name := range []string{"raw.html", "raw.pdf", "raw.json", "raw.txt", "raw.bin"} {
+		if name == keep {
+			continue
+		}
+		if err := removeIfExists(filepath.Join(dir, name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func removeIfExists(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("outputs: remove stale %s: %w", path, err)
 	}
 	return nil
 }

--- a/internal/orchestrator/outputs/fs_test.go
+++ b/internal/orchestrator/outputs/fs_test.go
@@ -237,7 +237,7 @@ func TestFSWriter_SaveReadingContent_SkipsNilExtracted(t *testing.T) {
 	w := New(root)
 
 	if err := w.SaveReadingContent(context.Background(), "bf_no_md",
-		[]byte("raw bytes"), nil, []byte(`{"content_type":"application/pdf"}`)); err != nil {
+		[]byte("raw bytes"), nil, []byte(`{"content_type":"application/pdf","content_status":"captured"}`)); err != nil {
 		t.Fatalf("SaveReadingContent: %v", err)
 	}
 
@@ -245,7 +245,38 @@ func TestFSWriter_SaveReadingContent_SkipsNilExtracted(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, "extracted.md")); !os.IsNotExist(err) {
 		t.Errorf("extracted.md should not exist, stat err = %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, "raw.html")); err != nil {
-		t.Errorf("raw.html should exist: %v", err)
+	if _, err := os.Stat(filepath.Join(dir, "raw.pdf")); err != nil {
+		t.Errorf("raw.pdf should exist: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "raw.html")); !os.IsNotExist(err) {
+		t.Errorf("raw.html should not exist for PDF capture, stat err = %v", err)
+	}
+}
+
+func TestFSWriter_SaveReadingContent_RemovesStaleArtifactsOnTypeChange(t *testing.T) {
+	root := t.TempDir()
+	w := New(root)
+
+	if err := w.SaveReadingContent(context.Background(), "bf_refresh",
+		[]byte("<html>old</html>"),
+		[]byte("# old"),
+		[]byte(`{"content_type":"text/html","content_status":"captured"}`)); err != nil {
+		t.Fatalf("first SaveReadingContent: %v", err)
+	}
+	if err := w.SaveReadingContent(context.Background(), "bf_refresh",
+		[]byte("%PDF-1.4\nnew"),
+		nil,
+		[]byte(`{"content_type":"application/pdf","content_status":"captured"}`)); err != nil {
+		t.Fatalf("second SaveReadingContent: %v", err)
+	}
+
+	dir := filepath.Join(root, "readings", "bf_refresh")
+	if _, err := os.Stat(filepath.Join(dir, "raw.pdf")); err != nil {
+		t.Errorf("raw.pdf should exist after PDF refresh: %v", err)
+	}
+	for _, stale := range []string{"raw.html", "extracted.md"} {
+		if _, err := os.Stat(filepath.Join(dir, stale)); !os.IsNotExist(err) {
+			t.Errorf("%s should have been removed on PDF refresh, stat err = %v", stale, err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Builds depth onto the slice 1 (#72 / #75) capture pipeline on `docker/reader/` per PRD #71. After this slice the capture pipeline behaves correctly across all the realistic failure modes, all non-HTML payload types covered by the PRD, and the force-overwrite + duplicate-discard semantics. Skill-agent (`docker/skill-agent/`) parity remains for slice 3.

Closes #73.

## What changed

**Failure handling**

- New env var `BACKFLOW_DEFAULT_READ_MAX_CONTENT_BYTES`, exposed on `TaskDefaults(\"read\").MaxContentBytes` and passed into reader containers as `MAX_CONTENT_BYTES` via the docker run env flags. Read-mode only — non-read tasks don't get the flag.
- `fetch-and-extract.sh` enforces the cap via `curl --max-filesize` and writes `content_status=over_size_cap` (no files on disk) on curl exit 63.
- HTTP 4xx/5xx, network/TLS errors, and empty bodies now write `content_status=fetch_failed` (no files on disk). Capture remains non-fatal — the agent's `WebFetch` summary path still runs.
- The orchestrator's `handleReadingCompletion` already gates `SaveReadingContent` on `content_status == \"captured\" && raw != nil`, so failure-status sidecars cleanly produce a row with `ContentStatus=fetch_failed` (or `over_size_cap`) and no on-disk artifacts. Webhook events propagate the failure status.
- `GET /api/v1/readings/{id}/content` and `/content/raw` continue to 404 when `content_status != \"captured\"` (slice 1 behavior, ratified with new tests for the failure-status path).

**Non-HTML content types**

- Fetcher derives an extension from `Content-Type` (`html` / `pdf` / `json` / `txt` / `bin`) and writes `raw.<ext>`. Extraction is skipped for non-HTML payloads, so no `extracted.md` is produced.
- `GET /content/raw` derives the on-disk filename from `reading.ContentType` (via a small mime → ext map kept in sync with the shell-side mapping) so PDF/JSON/text payloads serve correctly with their original `Content-Type` from the row.
- `GET /content` returns 404 for readings that have no extracted markdown (the existing `os.Stat` path), now covered explicitly by a non-HTML test case.

**Force / duplicate semantics**

- Bug fix in `handleReadingCompletion`: it generated a fresh ULID for the row, but `UpsertReading` uses `ON CONFLICT(url) DO UPDATE SET …` and does **not** update `id`. As a result, force-overwrite was orphaning fresh on-disk artifacts under a never-stored id while the row kept the old id, leaving the API endpoints unable to find the new content. The orchestrator now looks up the existing reading by URL before generating an id and reuses the existing id when present, so the upsert and the on-disk persist target the same `readings/{id}/` directory atomically. `content_sha256` reflects the latest fetch.
- Non-forced `novelty_verdict=duplicate` path now has a strengthened test asserting it skips `GetReadingContent` / `SaveReadingContent` / `UpsertReading` and leaves the existing row untouched (id, title, sha all preserved).
- The persister's overwrite path was already covered by `TestFSWriter_SaveReadingContent_Overwrites` in slice 1.

**Tests** (deep-module, per the PRD's Testing Decisions)

- Fetcher (`docker/reader/test_fetch_and_extract.sh`): adds HTTP 404, oversize-cap, and PDF/JSON/text non-HTML capture cases. The non-HTML cases use a second `python3 -m http.server` so the test gets real `Content-Type` headers from `mimetypes`.
- Container extractor (`internal/orchestrator/docker/reading_content_test.go`): adds a `FailureStatusSidecarOnly` case — sidecar present, raw absent.
- Monitor (`internal/orchestrator/monitor_test.go`):
  - `ReadSuccess_RecordsFetchFailedWithoutPersisting` (table-driven over `fetch_failed` and `over_size_cap`).
  - `ReadForce_OverwritesSameID` — pre-seeds an existing row, runs a forced read task for the same URL, asserts the upsert and the persister both target the existing id and that `content_sha256` reflects the latest fetch.
  - `ReadDuplicate_SkipsWrite` strengthened with a recording mock docker manager and a mockOut writer.
- Config (`internal/config/config_test.go`): asserts the new env var loads, `TaskDefaults(\"read\").MaxContentBytes` carries it, and `TaskDefaults(\"code\").MaxContentBytes` stays zero.
- Docker (`internal/orchestrator/docker/docker_test.go`): asserts read-mode `buildEnvFlags` includes `MAX_CONTENT_BYTES` and non-read flags omit it.

**Docs**

- `CLAUDE.md` reading-mode section now lists the failure modes, the env var, and the force/duplicate semantics. The slice-1 \"deferred to slice 2\" wording is removed; only `docker/skill-agent/` parity is called out as remaining work.

## Test plan

- [x] `make test` — all packages green, including new tests in `config/`, `api/`, `orchestrator/`, `orchestrator/docker/`
- [x] `make lint` — clean
- [x] `make test-reader-fetch-extract` — all five cases pass (happy path, missing URL, 404, oversize cap, non-HTML × 3)
- [x] `bash docker/reader/test_entrypoint.sh` — existing entrypoint tests still pass
- [x] `bash docker/reader/test_read_scripts.sh` — existing helper-script tests still pass
- [ ] Manual end-to-end on a real read task with a PDF / JSON / oversized URL: needs `make docker-reader-build-local` + a running orchestrator with `OPENAI_API_KEY` and `ANTHROPIC_API_KEY`. Verify the row's `content_status`, the on-disk `raw.<ext>`, and both HTTP endpoints round-trip.

## Out of scope (still deferred per PRD)

- `docker/skill-agent/` image parity — slice 3.
- `content_status=unsupported_type` — reserved enum value, no path produces it yet.
- Headless-browser capture for JS-rendered pages.
- PDF text extraction (`pdftotext`).
- Web app \"View original\" UI.
- Black-box read-mode coverage (no fake reader image yet).